### PR TITLE
fix: Add docs for first release

### DIFF
--- a/actual/api/__init__.py
+++ b/actual/api/__init__.py
@@ -178,6 +178,15 @@ class ActualServer:
         response.raise_for_status()
         return StatusDTO.model_validate(response.json())
 
+    def delete_user_file(self, file_id: str):
+        """Deletes the user file that is loaded from the remote server."""
+        response = requests.post(
+            f"{self.api_url}/{Endpoints.DELETE_USER_FILE}",
+            json={"fileId": file_id, "token": self._token},
+            headers=self.headers(),
+        )
+        return StatusDTO.model_validate(response.json())
+
     def user_get_key(self, file_id: str) -> UserGetKeyDTO:
         """Gets the key information associated with a user file, including the algorithm, key, salt and iv."""
         response = requests.post(

--- a/actual/api/models.py
+++ b/actual/api/models.py
@@ -21,6 +21,7 @@ class Endpoints(enum.Enum):
     DOWNLOAD_USER_FILE = "sync/download-user-file"
     UPLOAD_USER_FILE = "sync/upload-user-file"
     RESET_USER_FILE = "sync/reset-user-file"
+    DELETE_USER_FILE = "sync/delete-user-file"
     # encryption related
     USER_GET_KEY = "sync/user-get-key"
     USER_CREATE_KEY = "sync/user-create-key"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,7 @@
 import pytest
 
 from actual import Actual
-from actual.exceptions import ActualError
+from actual.exceptions import ActualError, UnknownFileId
 from actual.protobuf_models import Message
 
 
@@ -16,3 +16,12 @@ def test_api_apply(mocker):
     m.dataset = "accounts"
     with pytest.raises(ActualError, match="column 'bar' at table 'accounts' not found"):
         actual.apply_changes([m])
+
+
+def test_rename_delete_budget_without_file():
+    actual = Actual.__new__(Actual)
+    actual._file = None
+    with pytest.raises(UnknownFileId, match="No current file loaded"):
+        actual.delete_budget()
+    with pytest.raises(UnknownFileId, match="No current file loaded"):
+        actual.rename_budget("foo")


### PR DESCRIPTION
- Add how to install via pip (closes #14 )
- Small updates to the README documentation, including example on how to generate server backups
- Add option to delete budgets and test for reupload budget, after exporting it