### PR TITLE
ci: add job to try and build and import package

### DIFF
--- a/.github/workflows/try-build.yaml
+++ b/.github/workflows/try-build.yaml
@@ -1,0 +1,18 @@
+name: Test package for import errors and dependency installation
+on:
+  push:
+    branches: [ main ]
+jobs:
+  try-build:
+    name: Tries to build the package and import it
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+            python-version: "3.11"
+      - name: Install locally
+        run: python3 -m pip install .
+      - name: Test library import
+        run: cd / && python3 -c "from actual import Actual"


### PR DESCRIPTION
Checks if module imports are working on the built version, to prevent future importer errors like https://github.com/bvanelli/actualpy/issues/36

Closes https://github.com/bvanelli/actualpy/issues/38