### PR TITLE
feat: Support header login as a fallback in case server returns invalid-header

### DIFF
--- a/actual/api/models.py
+++ b/actual/api/models.py
@@ -51,15 +51,19 @@ class StatusCode(enum.Enum):
 
 class StatusDTO(BaseModel):
     status: StatusCode
+
+
+class ErrorStatusDTO(BaseModel):
+    status: StatusCode
     reason: Optional[str] = None
 
 
 class TokenDTO(BaseModel):
-    token: Optional[str] = None
+    token: Optional[str]
 
 
 class LoginDTO(StatusDTO):
-    data: Optional[TokenDTO] = None
+    data: TokenDTO
 
 
 class UploadUserFileDTO(StatusDTO):

--- a/actual/api/models.py
+++ b/actual/api/models.py
@@ -46,18 +46,20 @@ class BankSyncs(enum.Enum):
 
 class StatusCode(enum.Enum):
     OK = "ok"
+    ERROR = "error"
 
 
 class StatusDTO(BaseModel):
     status: StatusCode
+    reason: Optional[str] = None
 
 
 class TokenDTO(BaseModel):
-    token: Optional[str]
+    token: Optional[str] = None
 
 
 class LoginDTO(StatusDTO):
-    data: TokenDTO
+    data: Optional[TokenDTO] = None
 
 
 class UploadUserFileDTO(StatusDTO):


### PR DESCRIPTION
Closes https://github.com/bvanelli/actualpy/issues/43