### PR TITLE
fix: Cover rules including imported payees.

### DIFF
--- a/actual/queries.py
+++ b/actual/queries.py
@@ -224,11 +224,16 @@ def create_transaction(
     acct = get_account(s, account)
     if acct is None:
         raise ActualError(f"Account {account} not found")
+    if imported_payee:
+        imported_payee = imported_payee.strip()
+        if not payee:
+            payee = imported_payee
     payee = get_or_create_payee(s, payee)
     if category:
         category_id = get_or_create_category(s, category).id
     else:
         category_id = None
+
     return create_transaction_from_ids(
         s, date, acct.id, payee.id, notes, category_id, amount, imported_id, cleared, imported_payee
     )

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -191,3 +191,10 @@ def test_model_notes(session):
     session.commit()
     assert account_with_note.notes == "My note"
     assert account_without_note.notes is None
+
+
+def test_default_imported_payee(session):
+    t = create_transaction(session, date(2024, 1, 4), create_account(session, "Bank"), imported_payee=" foo ")
+    session.flush()
+    assert t.payee.name == "foo"
+    assert t.imported_description == "foo"


### PR DESCRIPTION
Implements the `imported_payee` type that was forgotten because it implements the exact same behaviour as string. There must be a reason why this was implemented, but as of now it implements exacly what STRING implements:

https://github.com/actualbudget/actual/blob/bbff543768eda550569c6e0a0a318446fbafaa0e/packages/loot-core/src/shared/rules.ts#L28-L50

Also trimmed the `imported_payee` as the original API does, and set it to the payee if it's missing.

Closes #67 