### PR TITLE
fix: Handle account sync errors when account is not properly setup.

### DIFF
--- a/actual/api/__init__.py
+++ b/actual/api/__init__.py
@@ -8,8 +8,8 @@ import requests
 
 from actual.api.models import (
     BankSyncAccountResponseDTO,
+    BankSyncResponseDTO,
     BankSyncStatusDTO,
-    BankSyncTransactionResponseDTO,
     BootstrapInfoDTO,
     Endpoints,
     GetUserFileInfoDTO,
@@ -284,7 +284,7 @@ class ActualServer:
         account_id: str,
         start_date: datetime.date,
         requisition_id: str = None,
-    ) -> BankSyncTransactionResponseDTO:
+    ) -> BankSyncResponseDTO:
         if bank_sync == "gocardless" and requisition_id is None:
             raise ActualInvalidOperationError("Retrieving transactions with goCardless requires `requisition_id`")
         endpoint = Endpoints.BANK_SYNC_TRANSACTIONS.value.format(bank_sync=bank_sync)
@@ -292,4 +292,4 @@ class ActualServer:
         if requisition_id:
             payload["requisitionId"] = requisition_id
         response = requests.post(f"{self.api_url}/{endpoint}", headers=self.headers(), json=payload, verify=self.cert)
-        return BankSyncTransactionResponseDTO.model_validate(response.json())
+        return BankSyncResponseDTO.validate_python(response.json())

--- a/actual/api/bank_sync.py
+++ b/actual/api/bank_sync.py
@@ -117,3 +117,10 @@ class BankSyncTransactionData(BaseModel):
     # goCardless specific
     iban: Optional[str] = None
     institution_id: Optional[str] = Field(None, alias="institutionId")
+
+
+class BankSyncErrorData(BaseModel):
+    error_type: str
+    error_code: str
+    status: Optional[str] = None
+    reason: Optional[str] = None

--- a/actual/api/models.py
+++ b/actual/api/models.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import enum
-from typing import List, Optional
+from typing import List, Optional, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, TypeAdapter
 
-from actual.api.bank_sync import BankSyncAccountData, BankSyncTransactionData
+from actual.api.bank_sync import (
+    BankSyncAccountData,
+    BankSyncErrorData,
+    BankSyncTransactionData,
+)
 
 
 class Endpoints(enum.Enum):
@@ -158,3 +162,10 @@ class BankSyncAccountResponseDTO(StatusDTO):
 
 class BankSyncTransactionResponseDTO(StatusDTO):
     data: BankSyncTransactionData
+
+
+class BankSyncErrorDTO(StatusDTO):
+    data: BankSyncErrorData
+
+
+BankSyncResponseDTO = TypeAdapter(Union[BankSyncErrorDTO, BankSyncTransactionResponseDTO])

--- a/actual/exceptions.py
+++ b/actual/exceptions.py
@@ -50,3 +50,8 @@ class ActualDecryptionError(ActualError):
 
 class ActualSplitTransactionError(ActualError):
     pass
+
+
+class ActualBankSyncError(ActualError):
+    def __init__(self, error_type: str, status: str = None, reason: str = None):
+        self.error_type, self.status, self.reason = error_type, status, reason


### PR DESCRIPTION
Test it  locally with the Simplefin demo. Here is what happens when the bank sync fails:

```
Traceback (most recent call last):
  File "/Users/brunno.vanelli/Documents/git/actualpy/dev/bank_sync.py", line 4, in <module>
    added = actual.run_bank_sync()
  File "/Users/brunno.vanelli/Documents/git/actualpy/actual/__init__.py", line 490, in run_bank_sync
    transactions = self._run_bank_sync_account(acct, default_start_date)
  File "/Users/brunno.vanelli/Documents/git/actualpy/actual/__init__.py", line 434, in _run_bank_sync_account
    raise ActualBankSyncError(
actual.exceptions.ActualBankSyncError: ('SERVER_DOWN', 'rejected', 'There was an error communciating with SimpleFIN.')
```

Closes #71 