### PR TITLE
fix: Floating-Point Representation and Precision Error in transaction amount calculation

### DIFF
--- a/actual/database.py
+++ b/actual/database.py
@@ -594,7 +594,7 @@ class Transactions(BaseModel, table=True):
         self.date = int(datetime.date.strftime(date, "%Y%m%d"))
 
     def set_amount(self, amount: Union[decimal.Decimal, int, float]):
-        self.amount = int(amount * 100)
+        self.amount = int(round(amount * 100))
 
     def get_amount(self) -> decimal.Decimal:
         return decimal.Decimal(self.amount) / decimal.Decimal(100)

--- a/actual/queries.py
+++ b/actual/queries.py
@@ -105,7 +105,7 @@ def match_transaction(
     date: datetime.date,
     account: str | Accounts,
     payee: str | Payees = "",
-    amount: decimal.Decimal | float | int = 0,
+    amount: decimal.Decimal | int = 0,
     imported_id: str | None = None,
     already_matched: list[Transactions] = None,
 ) -> typing.Optional[Transactions]:
@@ -196,7 +196,7 @@ def create_transaction(
     payee: str | Payees = "",
     notes: str | None = "",
     category: str | Categories | None = None,
-    amount: decimal.Decimal | float | int = 0,
+    amount: decimal.Decimal | int = 0,
     imported_id: str | None = None,
     cleared: bool = False,
     imported_payee: str = None,
@@ -269,7 +269,7 @@ def reconcile_transaction(
     payee: str | Payees = "",
     notes: str = "",
     category: str | Categories | None = None,
-    amount: decimal.Decimal | float | int = 0,
+    amount: decimal.Decimal | int = 0,
     imported_id: str | None = None,
     cleared: bool = False,
     imported_payee: str = None,
@@ -342,7 +342,7 @@ def create_splits(
     return split_transaction
 
 
-def create_split(s: Session, transaction: Transactions, amount: float | decimal.Decimal) -> Transactions:
+def create_split(s: Session, transaction: Transactions, amount: decimal.Decimal) -> Transactions:
     """
     Creates a transaction split based on the parent transaction. This is the opposite of create_splits, that joins
     all transactions as one big transaction. When using this method, you need to make sure all splits that you add to

--- a/actual/queries.py
+++ b/actual/queries.py
@@ -105,7 +105,7 @@ def match_transaction(
     date: datetime.date,
     account: str | Accounts,
     payee: str | Payees = "",
-    amount: decimal.Decimal | int = 0,
+    amount: decimal.Decimal | float | int = 0,
     imported_id: str | None = None,
     already_matched: list[Transactions] = None,
 ) -> typing.Optional[Transactions]:
@@ -129,7 +129,7 @@ def match_transaction(
     # if not matched, look 7 days ahead and 7 days back when fuzzy matching
     query = _transactions_base_query(
         s, date - datetime.timedelta(days=7), date + datetime.timedelta(days=8), account=account
-    ).filter(Transactions.amount == amount * 100)
+    ).filter(Transactions.amount == round(amount * 100))
     results: list[Transactions] = s.exec(query).all()  # noqa
     # filter out the ones that were already matched
     if already_matched:
@@ -175,7 +175,7 @@ def create_transaction_from_ids(
         id=str(uuid.uuid4()),
         acct=account_id,
         date=date_int,
-        amount=int(amount * 100),
+        amount=int(round(amount * 100)),
         category_id=category_id,
         payee_id=payee_id,
         notes=notes,
@@ -196,7 +196,7 @@ def create_transaction(
     payee: str | Payees = "",
     notes: str | None = "",
     category: str | Categories | None = None,
-    amount: decimal.Decimal | int = 0,
+    amount: decimal.Decimal | float | int = 0,
     imported_id: str | None = None,
     cleared: bool = False,
     imported_payee: str = None,
@@ -269,7 +269,7 @@ def reconcile_transaction(
     payee: str | Payees = "",
     notes: str = "",
     category: str | Categories | None = None,
-    amount: decimal.Decimal | int = 0,
+    amount: decimal.Decimal | float | int = 0,
     imported_id: str | None = None,
     cleared: bool = False,
     imported_payee: str = None,
@@ -342,7 +342,7 @@ def create_splits(
     return split_transaction
 
 
-def create_split(s: Session, transaction: Transactions, amount: decimal.Decimal) -> Transactions:
+def create_split(s: Session, transaction: Transactions, amount: float | decimal.Decimal) -> Transactions:
     """
     Creates a transaction split based on the parent transaction. This is the opposite of create_splits, that joins
     all transactions as one big transaction. When using this method, you need to make sure all splits that you add to

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -62,6 +62,21 @@ def test_account_relationships(session):
     assert [utilities_payment] == deleted_transaction
     assert get_accounts(session, "Bank") == [bank]
 
+def test_transaction(session: Actual.session):
+    today = date.today()
+    other = create_account(session, "Other")
+    coffee = create_transaction(
+        session, 
+        date=today, 
+        account="Other", 
+        payee="Starbucks", 
+        notes="coffee",
+        amount=float(-9.95)
+    )
+    session.commit()
+    assert coffee.amount == -9.95
+    assert len(other.transactions) == 1
+    assert other.balance == decimal.Decimal(-9.95)
 
 def test_reconcile_transaction(session):
     today = date.today()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -62,21 +62,18 @@ def test_account_relationships(session):
     assert [utilities_payment] == deleted_transaction
     assert get_accounts(session, "Bank") == [bank]
 
+
 def test_transaction(session: Actual.session):
     today = date.today()
     other = create_account(session, "Other")
     coffee = create_transaction(
-        session, 
-        date=today, 
-        account="Other", 
-        payee="Starbucks", 
-        notes="coffee",
-        amount=float(-9.95)
+        session, date=today, account="Other", payee="Starbucks", notes="coffee", amount=float(-9.95)
     )
     session.commit()
-    assert coffee.amount == -9.95
+    assert coffee.amount == -995
     assert len(other.transactions) == 1
-    assert other.balance == decimal.Decimal(-9.95)
+    assert other.balance == decimal.Decimal('-9.95')
+
 
 def test_reconcile_transaction(session):
     today = date.today()


### PR DESCRIPTION
The issue is related to floating-point arithmetic in Python, which affects the accuracy of transaction amount calculations. Specifically, when performing arithmetic operations with floating-point numbers, the results can sometimes be slightly off due to the way floating-point numbers are represented in binary format and when these transactions accumulate, the final account budget result is different from the reality(sometimes by a significant amount). This can lead to incorrect financial tracking and budgeting

#### Example
For instance, the calculation `-9.95 * 100` results in `-994.9999999999999` instead of the expected `-995` and results in amount of `-9.94` added to ActualBudget instead of `-9.95`.

### This might be a breaking change for some users that implemented float-type amount insert using `actualpy`

#### References
- [Python decimal module documentation](https://docs.python.org/3/library/decimal.html)
- [Floating-point arithmetic issues](https://docs.python.org/3/tutorial/floatingpoint.html)