### PR TITLE
perf: Improve performance of the apply changes method by grouping rows.

### DIFF
--- a/actual/database.py
+++ b/actual/database.py
@@ -13,9 +13,10 @@ protobuf change message using [actual.database.BaseModel.convert][].
 
 import datetime
 import decimal
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from sqlalchemy import MetaData, Table, engine, event, inspect
+from sqlalchemy.dialects.sqlite import insert
 from sqlalchemy.orm import class_mapper, object_session
 from sqlmodel import (
     Boolean,
@@ -27,6 +28,7 @@ from sqlmodel import (
     Integer,
     LargeBinary,
     Relationship,
+    Session,
     SQLModel,
     Text,
     func,
@@ -108,7 +110,18 @@ def get_attribute_by_table_name(table_name: str, column_name: str, reverse: bool
     )
 
 
-def strong_reference_session(session):
+def apply_change(
+    session: Session, table: Table, table_id: str, values: Dict[Column, Union[str, int, float, None]]
+) -> None:
+    """This function upserts multiple changes into a table based on the `table_id` as primary key. All the `values`
+    will be inserted as a new row, and if the id already exists, the values will be updated."""
+    insert_stmt = (
+        insert(table).values({"id": table_id, **values}).on_conflict_do_update(index_elements=["id"], set_=values)
+    )
+    session.exec(insert_stmt)  # noqa: Insert type here is correct
+
+
+def strong_reference_session(session: Session):
     @event.listens_for(session, "before_flush")
     def before_flush(sess, flush_context, instances):
         if len(sess.deleted):


### PR DESCRIPTION
Improves the speed when having thousands of entries on the sync backlog by grouping them together. This should make sure that the inserts are done in a single query (INSERT ... ON CONFLICT UPDATE), but should also newly created entities  fields together, making the queries more efficient. Over testing, this helped improve performance of budget with high number of entries high, but also keep the performance of newly created budgets (without many changes) the same. 

Closes #87 