### PR TITLE
ci: Add build docs job to prevent pushing broken docs to main.

### DIFF
--- a/.github/workflows/try-build-docs.yaml
+++ b/.github/workflows/try-build-docs.yaml
@@ -1,0 +1,17 @@
+name: Try building the documentation to prevent cross-reference issues
+
+on:
+  pull_request:
+
+jobs:
+  try-build-docs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.11"
+    - name: Install project dependencies
+      run: python3 -m pip install --user -r docs/requirements.txt
+    - name: Try building the documentation
+      run: mkdocs build


### PR DESCRIPTION
Prevents broken documentation links by building docs on PRs.