### PR TITLE
fix: Adjust model for Balance.reference_date to be None if not passed (field is optional)

### DIFF
--- a/actual/api/bank_sync.py
+++ b/actual/api/bank_sync.py
@@ -60,7 +60,7 @@ class Balance(BaseModel):
 
     balance_amount: BankSyncAmount = Field(..., alias="balanceAmount")
     balance_type: BalanceType = Field(..., alias="balanceType")
-    reference_date: Optional[str] | None = Field(None, alias="referenceDate", description="The date of the balance")
+    reference_date: Optional[str] = Field(None, alias="referenceDate", description="The date of the balance")
 
 
 class TransactionItem(BaseModel):

--- a/actual/api/bank_sync.py
+++ b/actual/api/bank_sync.py
@@ -60,7 +60,7 @@ class Balance(BaseModel):
 
     balance_amount: BankSyncAmount = Field(..., alias="balanceAmount")
     balance_type: BalanceType = Field(..., alias="balanceType")
-    reference_date: Optional[str] = Field(..., alias="referenceDate", description="The date of the balance")
+    reference_date: Optional[str] | None = Field(None, alias="referenceDate", description="The date of the balance")
 
 
 class TransactionItem(BaseModel):


### PR DESCRIPTION
Proposal fix for issue https://github.com/bvanelli/actualpy/issues/99

