### PR TITLE
feat: Handle balances when using Bank Sync

### DIFF
--- a/actual/api/bank_sync.py
+++ b/actual/api/bank_sync.py
@@ -118,6 +118,10 @@ class BankSyncTransactionData(BaseModel):
     iban: Optional[str] = None
     institution_id: Optional[str] = Field(None, alias="institutionId")
 
+    @property
+    def balance(self) -> decimal.Decimal:
+        return decimal.Decimal(self.starting_balance) / 100
+
 
 class BankSyncErrorData(BaseModel):
     error_type: str

--- a/actual/api/bank_sync.py
+++ b/actual/api/bank_sync.py
@@ -65,16 +65,16 @@ class Balance(BaseModel):
 
 class TransactionItem(BaseModel):
     transaction_id: str = Field(..., alias="transactionId")
-    booking_date: str = Field(..., alias="bookingDate")
     booked: bool = True
-    value_date: str = Field(..., alias="valueDate")
     transaction_amount: BankSyncAmount = Field(..., alias="transactionAmount")
     # this field will come as either debtorName or creditorName, depending on if it's a debt or credit
     payee: str = Field(None, validation_alias=AliasChoices("debtorName", "creditorName"))
     payee_account: Optional[DebtorAccount] = Field(
         None, validation_alias=AliasChoices("debtorAccount", "creditorAccount")
     )
-    date: datetime.date
+    # 'bookingDate' and 'valueDate' can be null or not existing in some goCardless data. Actual does not use them.
+    # Therefore, we just use them as fallbacks for the date, that should theoretically always exist.
+    date: datetime.date = Field(..., validation_alias=AliasChoices("date", "bookingDate", "valueDate"))
     remittance_information_unstructured: str = Field(None, alias="remittanceInformationUnstructured")
     remittance_information_unstructured_array: List[str] = Field(
         default_factory=list, alias="remittanceInformationUnstructuredArray"
@@ -97,7 +97,7 @@ class TransactionItem(BaseModel):
         notes = self.remittance_information_unstructured or ", ".join(
             self.remittance_information_unstructured_array or []
         )
-        return notes.strip()
+        return notes.strip().replace("#", "##")
 
 
 class Transactions(BaseModel):

--- a/actual/queries.py
+++ b/actual/queries.py
@@ -605,7 +605,8 @@ def get_budgets(
     :param month: month to get budgets for, as a date for that month. Use `datetime.date.today()` if you want the budget
                   for current month
     :param category: category to filter for the budget. By default, the query looks for all budgets.
-    :return: list of budgets
+    :return: list of budgets. It's important to note that budgets will only exist if they are actively set beforehand.
+             When the frontend shows a budget as 0.00, it might not be returned by this method.
     """
     table = _get_budget_table(s)
     query = select(table).options(joinedload(table.category))
@@ -630,7 +631,8 @@ def get_budget(
     :param month: month to get budgets for, as a date for that month. Use `datetime.date.today()` if you want the budget
                   for current month.
     :param category: category to filter for the budget.
-    :return: return budget matching the month and category. If not found, returns `None`.
+    :return: returns the budget matching the month and category. If not found, returns `None`. If the budget is not
+             set via frontend, it will show as 0.00, but this function will still return `None`.
     """
     budgets = get_budgets(s, month, category)
     return budgets[0] if budgets else None


### PR DESCRIPTION
Allows the accounts to be reconciled when doing the first bank sync. This happens when the expected balance of the account does not match the final balance of the imported transactions, because old transactions are not imported.

This should only affect the first import using the bank sync, or if all transactions are deleted and a new bank sync is done.

Either way, it manages to reproduce 1:1 what we find on the simpleFin demo dataset, when importing from Actual or actualpy.

Closes #29 