### PR TITLE
feat: Add option to run rules on bank sync.

### DIFF
--- a/docs/experimental-features.md
+++ b/docs/experimental-features.md
@@ -66,6 +66,15 @@ with Actual(base_url="http://localhost:5006", password="mypass", file="My budget
     actual.commit()
 ```
 
+If you are running bank sync, you can also run rules directly on the imported transactions after doing the sync:
+
+```python
+from actual import Actual
+
+with Actual(base_url="http://localhost:5006", password="mypass") as actual:
+    synchronized_transactions = actual.run_bank_sync(run_rules=True)
+```
+
 You can also manipulate the rules individually, and validate each rule that runs for each transaction, allowing you
 to also debug rules. This can be useful when more than one rule is modifying the same transaction, but the order of
 operations is not correct:

--- a/tests/test_bank_sync.py
+++ b/tests/test_bank_sync.py
@@ -178,7 +178,7 @@ def test_bank_sync_with_starting_balance(session, bank_sync_data_no_match):
         actual._session = session
         create_accounts(session, "simpleFin")
         # now try to run the bank sync
-        imported_transactions = actual.run_bank_sync("Bank")
+        imported_transactions = actual.run_bank_sync("Bank", run_rules=True)
         assert len(imported_transactions) == 3
         # first transaction should be the amount
         assert imported_transactions[0].get_date() == datetime.date(2024, 6, 13)


### PR DESCRIPTION
Adds an option to run rules after importing the transactions, disabled by default.

Also reported in #68

Closes #30 