### PR TITLE
feat: Make sure the tmp folder is consistent

### DIFF
--- a/actual/utils/storage.py
+++ b/actual/utils/storage.py
@@ -1,0 +1,22 @@
+import pathlib
+import tempfile
+from typing import Union
+
+
+def get_base_tmp_folder() -> pathlib.Path:
+    """Returns the temporary folder that the library should use to store temporary files if the user does not provide
+    a folder path."""
+    base_tmp_dir = pathlib.Path(tempfile.gettempdir())
+    tmp_dir = base_tmp_dir / "actualpy"
+    tmp_dir.mkdir(exist_ok=True)
+    return tmp_dir
+
+
+def get_tmp_folder(file_id: Union[str, None]) -> pathlib.Path:
+    """Returns a base folder to store the file based on the file id. Will create the folder if not existing."""
+    if not file_id:
+        folder = pathlib.Path(tempfile.mkdtemp())
+    else:
+        folder = get_base_tmp_folder() / str(file_id)
+        folder.mkdir(exist_ok=True)
+    return folder

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+import zipfile
 from unittest.mock import patch
 
 import pytest
@@ -69,3 +70,15 @@ def test_set_file_exceptions(mocker):
     )
     with pytest.raises(ActualError, match="Multiple files found with identifier 'foo'"):
         actual.set_file("foo")
+
+
+def test_zip_exceptions(mocker, tmp_path):
+    mocker.patch("actual.Actual.validate")
+    mocker.patch("actual.Actual.create_engine")
+    archive = tmp_path / "file.zip"
+    with zipfile.ZipFile(archive, "w"):
+        pass
+    actual = Actual(token="foo")
+    actual.import_zip(archive)
+    # archive will use a normal temp folder since the cloudFileId is missing from metadata
+    assert actual._data_dir.name.startswith("tmp")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -139,10 +139,15 @@ def test_redownload_file(actual_server, tmp_path):
     with Actual(f"http://localhost:{port}", password="mypass", bootstrap=True) as actual:
         actual.create_budget("My Budget")
         actual.upload_budget()
+        file_id = actual.get_metadata()["cloudFileId"]
+    # do a normal download and see if the folder matches the fileId that was initially generated
+    with Actual(f"http://localhost:{port}", password="mypass", file="My Budget") as actual:
+        assert str(actual._data_dir).endswith(file_id)
     # download to a certain folder
     with Actual(f"http://localhost:{port}", password="mypass", file="My Budget", data_dir=tmp_path) as actual:
         get_or_create_account(actual.session, "Bank")
         actual.commit()
+        assert not str(actual._data_dir).endswith(file_id)
     # reupload the budget
     with Actual(f"http://localhost:{port}", password="mypass", file="My Budget", data_dir=tmp_path) as actual:
         actual.reupload_budget()


### PR DESCRIPTION
When launching the application multiple times, the storage folder is always picked at random if not provided.

The PR makes sure that the uuid will be extracted from the `metadata.json` and then used to create a path that does not require the budget to be redowloaded every time, making the application faster when a storage folder is not provided but the script is called multiple times (i.e. development scenario).

Closes #122 