### PR TITLE
feat: Add query to retrieve the budget balance.

### DIFF
--- a/actual/api/__init__.py
+++ b/actual/api/__init__.py
@@ -90,13 +90,15 @@ class ActualServer:
                 json={"loginMethod": method},
                 headers={"X-ACTUAL-PASSWORD": password},
             )
-        response_dict = response.json()
         if response.status_code == 400 and "invalid-password" in response.text:
             raise AuthorizationError("Could not validate password on login.")
         elif response.status_code == 200 and "invalid-header" in response.text:
             # try the same login with the header
             return self.login(password, "header")
-        elif response_dict["status"] == "error":
+        elif response.status_code > 300:
+            raise AuthorizationError(f"Server returned an HTTP error '{response.status_code}': '{response.text}'")
+        response_dict = response.json()
+        if response_dict["status"] == "error":
             # for example, when not trusting the proxy
             raise AuthorizationError(f"Something went wrong on login: {response_dict['reason']}")
         login_response = LoginDTO.model_validate(response.json())

--- a/actual/api/__init__.py
+++ b/actual/api/__init__.py
@@ -95,7 +95,7 @@ class ActualServer:
         elif response.status_code == 200 and "invalid-header" in response.text:
             # try the same login with the header
             return self.login(password, "header")
-        elif response.status_code > 300:
+        elif response.status_code > 400:
             raise AuthorizationError(f"Server returned an HTTP error '{response.status_code}': '{response.text}'")
         response_dict = response.json()
         if response_dict["status"] == "error":

--- a/actual/database.py
+++ b/actual/database.py
@@ -758,10 +758,13 @@ class BaseBudgets(BaseModel):
     @property
     def balance(self) -> decimal.Decimal:
         """
-        Returns the current balance of the budget.
+        Returns the current **spent** balance of the budget.
 
         The evaluation will take into account the budget month and only selected transactions for the combination month
         and category. Deleted transactions are ignored.
+
+        If you want to get the balance from the frontend, take a look at the query
+        [get_accumulated_budgeted_balance][actual.queries.get_accumulated_budgeted_balance] instead.
         """
         budget_start, budget_end = (int(datetime.date.strftime(d, "%Y%m%d")) for d in self.range)
         value = object_session(self).scalar(

--- a/actual/database.py
+++ b/actual/database.py
@@ -42,6 +42,7 @@ from sqlmodel import (
 
 from actual.exceptions import ActualInvalidOperationError
 from actual.protobuf_models import HULC_Client, Message
+from actual.utils.conversions import cents_to_decimal, date_to_int, decimal_to_cents, int_to_date, month_range
 
 """
 This variable contains the internal model mappings for all databases. It solves a couple of issues, namely having the
@@ -263,7 +264,7 @@ class Accounts(BaseModel, table=True):
                 Transactions.tombstone == 0,
             )
         )
-        return decimal.Decimal(value) / 100
+        return cents_to_decimal(value)
 
     @property
     def notes(self) -> Optional[str]:
@@ -336,7 +337,7 @@ class Categories(BaseModel, table=True):
                 Transactions.tombstone == 0,
             )
         )
-        return decimal.Decimal(value) / 100
+        return cents_to_decimal(value)
 
 
 class CategoryGroups(BaseModel, table=True):
@@ -525,7 +526,7 @@ class Payees(BaseModel, table=True):
                 Transactions.tombstone == 0,
             )
         )
-        return decimal.Decimal(value) / 100
+        return cents_to_decimal(value)
 
 
 class Preferences(BaseModel, table=True):
@@ -687,19 +688,19 @@ class Transactions(BaseModel, table=True):
 
     def get_date(self) -> datetime.date:
         """Returns the transaction date as a datetime.date object, instead of as a string."""
-        return datetime.datetime.strptime(str(self.date), "%Y%m%d").date()
+        return int_to_date(self.date)
 
     def set_date(self, date: datetime.date):
         """Sets the transaction date as a datetime.date object, instead of as a string."""
-        self.date = int(datetime.date.strftime(date, "%Y%m%d"))
+        self.date = date_to_int(date)
 
     def set_amount(self, amount: Union[decimal.Decimal, int, float]):
         """Sets the amount as a decimal.Decimal object, instead of as an integer representing the number of cents."""
-        self.amount = int(round(amount * 100))
+        self.amount = decimal_to_cents(amount)
 
     def get_amount(self) -> decimal.Decimal:
         """Returns the amount as a decimal.Decimal, instead of as an integer representing the number of cents."""
-        return decimal.Decimal(self.amount) / decimal.Decimal(100)
+        return cents_to_decimal(self.amount)
 
 
 class ZeroBudgetMonths(SQLModel, table=True):
@@ -724,7 +725,7 @@ class BaseBudgets(BaseModel):
 
     def get_date(self) -> datetime.date:
         """Returns the transaction date as a datetime.date object, instead of as a string."""
-        return datetime.datetime.strptime(str(self.month), "%Y%m").date()
+        return int_to_date(self.month, month_only=True)
 
     def set_date(self, date: datetime.date):
         """
@@ -733,15 +734,15 @@ class BaseBudgets(BaseModel):
         If the date value contains a day, it will be truncated and only the month and year will be inserted, as the
         budget applies to a month.
         """
-        self.month = int(datetime.date.strftime(date, "%Y%m"))
+        self.month = date_to_int(date, month_only=True)
 
     def set_amount(self, amount: Union[decimal.Decimal, int, float]):
         """Sets the amount as a decimal.Decimal object, instead of as an integer representing the number of cents."""
-        self.amount = int(round(amount * 100))
+        self.amount = decimal_to_cents(amount)
 
     def get_amount(self) -> decimal.Decimal:
         """Returns the amount as a decimal.Decimal, instead of as an integer representing the number of cents."""
-        return decimal.Decimal(self.amount) / decimal.Decimal(100)
+        return cents_to_decimal(self.amount)
 
     @property
     def range(self) -> Tuple[datetime.date, datetime.date]:
@@ -750,10 +751,7 @@ class BaseBudgets(BaseModel):
 
         The end date is not inclusive, as it represents the start of the next month.
         """
-        budget_start = self.get_date().replace(day=1)
-        # conversion taken from https://stackoverflow.com/a/59199379/12681470
-        budget_end = (budget_start + datetime.timedelta(days=32)).replace(day=1)
-        return budget_start, budget_end
+        return month_range(self.get_date())
 
     @property
     def balance(self) -> decimal.Decimal:
@@ -766,7 +764,7 @@ class BaseBudgets(BaseModel):
         If you want to get the balance from the frontend, take a look at the query
         [get_accumulated_budgeted_balance][actual.queries.get_accumulated_budgeted_balance] instead.
         """
-        budget_start, budget_end = (int(datetime.date.strftime(d, "%Y%m%d")) for d in self.range)
+        budget_start, budget_end = (date_to_int(d) for d in self.range)
         value = object_session(self).scalar(
             select(func.coalesce(func.sum(Transactions.amount), 0)).where(
                 Transactions.category_id == self.category_id,
@@ -776,7 +774,7 @@ class BaseBudgets(BaseModel):
                 Transactions.tombstone == 0,
             )
         )
-        return decimal.Decimal(value) / 100
+        return cents_to_decimal(value)
 
 
 class ReflectBudgets(BaseBudgets, table=True):

--- a/actual/protobuf_models.py
+++ b/actual/protobuf_models.py
@@ -49,7 +49,7 @@ class HULC_Client:
         for reference.
         """
         if not now:
-            now = datetime.datetime.utcnow()
+            now = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)
         count = f"{self.initial_count:0>4X}"
         self.initial_count += 1
         return f"{now.isoformat(timespec='milliseconds')}Z-{count}-{self.client_id}"

--- a/actual/queries.py
+++ b/actual/queries.py
@@ -736,6 +736,10 @@ def get_budgeted_balance(s: Session, month: datetime.date, category: str | Categ
 
 
 def _get_first_positive_transaction(s: Session, category: Categories) -> typing.Optional[Transactions]:
+    """
+    Returns the first positive transaction in a certain category. This is used to find the month to start the
+    budgeting calculation, since it makes the budget positive.
+    """
     query = select(Transactions).where(Transactions.amount > 0, Transactions.category_id == category.id)
     return s.exec(query).first()
 

--- a/actual/utils/conversions.py
+++ b/actual/utils/conversions.py
@@ -1,0 +1,54 @@
+import datetime
+import decimal
+from typing import Tuple
+
+
+def date_to_int(date: datetime.date, month_only: bool = False) -> int:
+    """
+    Converts a date object to an integer representation. For example, the `date(2025, 3, 10)` gets converted to
+    `20250310`.
+
+    If `month_only` is set to `True`, the day will be removed from the date. For example, the same date above gets
+    converted to `202503`.
+    """
+    date_format = "%Y%m" if month_only else "%Y%m%d"
+    return int(datetime.date.strftime(date, date_format))
+
+
+def int_to_date(date: int | str, month_only: bool = False) -> datetime.date:
+    """
+    Converts an `int` or `str` object to the `datetime.date` representation. For example, the int `20250310`
+    gets converted to `date(2025, 3, 10)`.
+    """
+    date_format = "%Y%m" if month_only else "%Y%m%d"
+    return datetime.datetime.strptime(str(date), date_format).date()
+
+
+def month_range(month: datetime.date) -> Tuple[datetime.date, datetime.date]:
+    """
+    Range of the provided `month` as a tuple [start, end).
+
+    The end date is not inclusive, as it represents the start of the next month.
+    """
+    range_start = month.replace(day=1)
+    # conversion taken from https://stackoverflow.com/a/59199379/12681470
+    range_end = (range_start + datetime.timedelta(days=32)).replace(day=1)
+    return range_start, range_end
+
+
+def current_timestamp() -> int:
+    """Returns the current timestamp in milliseconds, using UTC time."""
+    return int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
+
+
+def cents_to_decimal(amount: int) -> decimal.Decimal:
+    """Converts the number of cents to a `decimal.Decimal` object. When providing `500`, the result will be
+    `decimal.Decimal(5.0)`.
+    """
+    return decimal.Decimal(amount) / decimal.Decimal(100)
+
+
+def decimal_to_cents(amount: decimal.Decimal | int | float) -> int:
+    """Converts the decimal amount (`decimal.Decimal` or `int` or `float`) to an integer value. When providing
+    `decimal.Decimal(5.0)`, the result will be `500`."""
+    return int(round(amount * 100))

--- a/actual/utils/conversions.py
+++ b/actual/utils/conversions.py
@@ -40,7 +40,7 @@ def month_range(month: datetime.date) -> Tuple[datetime.date, datetime.date]:
 
 def current_timestamp() -> int:
     """Returns the current timestamp in milliseconds, using UTC time."""
-    return int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
+    return int(datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).timestamp() * 1000)
 
 
 def cents_to_decimal(amount: int) -> decimal.Decimal:

--- a/actual/utils/conversions.py
+++ b/actual/utils/conversions.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import datetime
 import decimal
 from typing import Tuple

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -47,6 +47,16 @@ def test_api_login_unknown_error(_post, mocker):
         actual.login("foo")
 
 
+@patch.object(Session, "post", return_value=RequestsMock({}, status_code=403))
+def test_api_login_http_error(_post, mocker):
+    mocker.patch("actual.Actual.validate")
+    actual = Actual(token="foo")
+    actual.api_url = "localhost"
+    actual.cert = False
+    with pytest.raises(AuthorizationError, match="HTTP error '403'"):
+        actual.login("foo")
+
+
 def test_no_certificate(mocker):
     mocker.patch("actual.Actual.validate")
     actual = Actual(token="foo", cert=False)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -16,7 +16,6 @@ from actual.queries import (
     create_transfer,
     get_accounts,
     get_accumulated_budgeted_balance,
-    get_budget,
     get_budgets,
     get_or_create_category,
     get_or_create_clock,
@@ -276,7 +275,6 @@ def test_accumulated_budget_amount(
 
     assert get_accumulated_budgeted_balance(session, date(2025, 2, 1), category) == expected_value_previous_month
     assert get_accumulated_budgeted_balance(session, date(2025, 3, 1), category) == expected_value_current_month
-    assert get_budget(session, date(2024, 10, 1), category) is None
 
 
 def test_normalize_payee():

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -150,6 +150,9 @@ def test_create_splits(session):
     parents = get_transactions(session, is_parent=True)
     assert len(parents) == 1
     assert len(parents[0].splits) == 2
+    # find all with category
+    category = get_transactions(session, category="Dining")
+    assert len(category) == 1
 
 
 def test_create_splits_error(session):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -16,6 +16,7 @@ from actual.queries import (
     create_transfer,
     get_accounts,
     get_accumulated_budgeted_balance,
+    get_budget,
     get_budgets,
     get_or_create_category,
     get_or_create_clock,
@@ -275,6 +276,7 @@ def test_accumulated_budget_amount(
 
     assert get_accumulated_budgeted_balance(session, date(2025, 2, 1), category) == expected_value_previous_month
     assert get_accumulated_budgeted_balance(session, date(2025, 3, 1), category) == expected_value_current_month
+    assert get_budget(session, date(2024, 10, 1), category) is None
 
 
 def test_normalize_payee():

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,6 +9,7 @@ from actual.database import (
     get_attribute_by_table_name,
     get_class_by_table_name,
 )
+from actual.utils.conversions import current_timestamp
 
 
 def test_get_class_by_table_name():
@@ -34,7 +35,7 @@ def test_conversion():
         amount=1000,
         reconciled=0,
         cleared=0,
-        sort_order=datetime.datetime.utcnow().timestamp(),
+        sort_order=current_timestamp(),
     )
     t.set_amount(10)
     t.set_date(datetime.date(2024, 3, 17))


### PR DESCRIPTION
Creates functions:

- `get_budgeted_balance`: Returns the budgeted balance as shown by the Actual UI under the category for the individual month. Does not take into account previous months.
- `get_accumulated_budgeted_balance`: Returns the budgeted balance as shown by the Actual UI under the category. This is calculated by summing all considered budget values and subtracting all transactions for them.

Tested performance on my own budget and it looks like budgets are returned in less than 0.02 seconds, so it should be performant enough even with multiple consecutive queries.