### PR TITLE
Support adding custom headers

### DIFF
--- a/actual/__init__.py
+++ b/actual/__init__.py
@@ -55,6 +55,7 @@ class Actual(ActualServer):
         base_url: str = "http://localhost:5006",
         token: str = None,
         password: str = None,
+        extra_headers: dict[str, str] = None,
         file: str = None,
         encryption_password: str = None,
         data_dir: Union[str, pathlib.Path] = None,
@@ -72,6 +73,7 @@ class Actual(ActualServer):
         :param base_url: url of the running Actual server
         :param token: the token for authentication, if this is available (optional)
         :param password: the password for authentication. It will be used on the .login() method to retrieve the token.
+        :param extra_headers: additional headers to be attached to each request to the Actual server
         :param file: the name or id of the file to be set
         :param encryption_password: password used to configure encryption, if existing
         :param data_dir: where to store the downloaded files from the server. If not specified, a temporary folder will
@@ -84,7 +86,7 @@ class Actual(ActualServer):
         by default), `autocommit` (disabled by default). For a list of all parameters, check the [SQLAlchemy
         documentation.](https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.__init__)
         """
-        super().__init__(base_url, token, password, bootstrap, cert)
+        super().__init__(base_url, token, password, extra_headers, bootstrap, cert)
         self._file: RemoteFileListDTO | None = None
         self._data_dir = pathlib.Path(data_dir) if data_dir else None
         self.engine = None

--- a/actual/api/__init__.py
+++ b/actual/api/__init__.py
@@ -38,6 +38,7 @@ class ActualServer:
         base_url: str = "http://localhost:5006",
         token: str = None,
         password: str = None,
+        extra_headers: dict[str, str] = None,
         bootstrap: bool = False,
         cert: str | bool = None,
     ):
@@ -49,6 +50,7 @@ class ActualServer:
         :param token: the token for authentication, if this is available (optional)
         :param password: the password for authentication. It will be used on the .login() method to retrieve the token.
         be created instead.
+        :param extra_headers: additional headers to be attached to each request to the Actual server
         :param bootstrap: if the server is not bootstrapped, bootstrap it with the password.
         :param cert: if a custom certificate should be used (i.e. self-signed certificate), it's path can be provided
                      as a string. Set to `False` for no certificate check.
@@ -56,6 +58,8 @@ class ActualServer:
         self.api_url: str = base_url
         self._token: str | None = token
         self._requests_session: requests.Session = requests.Session()
+        if extra_headers:
+            self._requests_session.headers = extra_headers
         if cert is not None:
             self._requests_session.verify = cert
         if token is None and password is None:
@@ -66,7 +70,7 @@ class ActualServer:
         elif password:
             self.login(password)
         # set default headers for the connection
-        self._requests_session.headers = self.headers()
+        self._requests_session.headers.update(self.headers())
         # finally call validate
         self.validate()
 


### PR DESCRIPTION
## Overview

When the actual server sits behind a reverse proxy with an additional authentication layer, additional auth headers should be added to each request. To the best of my knowledge this is currently not possible with`actualpy`.

## Proposal

This PR allows passing an optional `extra_headers` dictionary when constructing the `Actual` object.
These headers will be added to each request the client sends to the server.

## QA

Tested by connecting to the server deployed behind Cloudflare Zero Trust which requires service token auth.
In order to connect to the server `CF-Access-Client-Id` and `CF-Access-Client-Secret` headers were added using the changes in this branch.