### PR TITLE
fix: Fix a bug where transfer payee was not set

### DIFF
--- a/actual/queries.py
+++ b/actual/queries.py
@@ -853,6 +853,9 @@ def create_transfer(
     # swap the transferred ids
     source_transaction.transferred_id = dest_transaction.id
     dest_transaction.transferred_id = source_transaction.id
+    # set payees
+    source_transaction.payee_id = dest.payee.id
+    dest_transaction.payee_id = source.payee.id
     # add and return objects
     s.add(source_transaction)
     s.add(dest_transaction)

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -89,6 +89,16 @@ def test_transaction_without_payee(session):
     assert tr.payee_id is None
 
 
+def test_transfer(session):
+    bank = create_account(session, "Bank", 200)
+    savings = create_account(session, "Savings")
+    origin, dst = create_transfer(session, date.today(), "Bank", "Savings", 200, "Saving money")
+    assert origin.payee_id == savings.payee.id
+    assert dst.payee_id == bank.payee.id
+    assert bank.balance == decimal.Decimal(0.0)
+    assert savings.balance == decimal.Decimal(200.0)
+
+
 def test_reconcile_transaction(session):
     today = date.today()
     create_account(session, "Bank")


### PR DESCRIPTION
A few server updates ago (sorry I don't remember when exactly) the `create_transfer` functionality stopped working properly.
When I use the method to create a transfer, the `Payee` field was not set in Actual (it was before IIRC).
After a few experiments and peeking into the sqlite db, I figured, the `payee_id` field must be set on the transaction object.  

This change fixed the bug for me on `v25.6.1`, but I am not sure if it's compatible with older version.
Keen to hear what you think about this.
Thanks!