### PR TITLE
fix: Update cleared flag for matches in reconcile_transaction

### DIFF
--- a/actual/queries.py
+++ b/actual/queries.py
@@ -418,6 +418,7 @@ def reconcile_transaction(
         # try to update fields
         if update_existing:
             match.notes = notes
+            match.cleared = cleared
             if category:
                 match.category_id = get_or_create_category(s, category).id
             match.set_date(date)


### PR DESCRIPTION
When using reconcile_transaction for creating/updating transactions with update_existing set to True the cleared flag is currently ignored when doing updates.

Also updating the cleared-flag enables scripted clearing of transactions during imports where the sources data includes preliminary or upcoming transactions which can be initially imported with cleared=False and at a later point in time reimported using reconsile_transaction with cleared=True. This way this status is mirrored into actual.

Beware that this could affect users relying on the curreny logic where callw with update_existing=True currently does not touch the cleared flag, hence this could be a breaking change for certain use-cases.