### PR TITLE
Use the pytest tmp_path fixture instead of tempfile

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import tempfile
 
 import pytest
 from sqlmodel import Session, create_engine
@@ -29,10 +28,9 @@ class RequestsMock:
 
 
 @pytest.fixture
-def session():
-    with tempfile.NamedTemporaryFile() as f:
-        sqlite_url = f"sqlite:///{f.name}"
-        engine = create_engine(sqlite_url, connect_args={"check_same_thread": False})
-        SQLModel.metadata.create_all(engine)
-        with Session(engine, autoflush=True) as session:
-            yield strong_reference_session(session)
+def session(tmp_path):
+    sqlite_url = f"sqlite:///{tmp_path}/pytest.sqlite"
+    engine = create_engine(sqlite_url, connect_args={"check_same_thread": False})
+    SQLModel.metadata.create_all(engine)
+    with Session(engine, autoflush=True) as session:
+        yield strong_reference_session(session)


### PR DESCRIPTION
Currently the module tempfile is used for creating a tempfile for the sqllite used for tests. This fails on windows due to file locking resulting in all test cases failing.

There is a built-in fixture in pytest which creates structured temporary directories and alse purges them automatically. This PR replaces the previous tempfile structure with the pytest fixture. The default is that these temporary directories are kept for three generations, see https://docs.pytest.org/en/stable/how-to/tmp_path.html for more information. 

With this fix most of the test cases works as-is on Windows, I will go through the ones that still fail to see if they can be fixed as well.