### PR TITLE
Pytest fixes for windows

### DIFF
--- a/actual/__init__.py
+++ b/actual/__init__.py
@@ -198,7 +198,8 @@ class Actual(ActualServer):
                 migration = self.data_file(file)  # retrieves file from actual server
                 sql_statements = migration.decode()
                 if file.endswith(".js"):
-                    # there is one migration which is Javascript. All entries inside db.execQuery(`...`) must be executed
+                    # There is at least one migration which is a Javascript file.
+                    # All entries inside db.execQuery(`...`) must be executed
                     exec_entries = js_migration_statements(sql_statements)
                     sql_statements = "\n".join(exec_entries)
                 conn.executescript(sql_statements)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,4 @@
 import datetime
-import sys
 
 import pytest
 from sqlalchemy import delete, select


### PR DESCRIPTION
As pointed out in #166 there are some tests which still fail on Windows due to various reasons. This PR makes the test suite pass.
* The os.sep commit should be trivial to understand.
* For the CLI tests it was not, as expected, the newlines causing problems but rather it was the Table generator using different sets of unicode chars for rendering the table on win32 compared to other OS:s. This seems to be a known issue with rich. These test we modified to be more tolerant and less strict on formatting.
* The redownload test fails due to the sqlite file being opened by the test harness which causes the unlink to fail. Getting this to work would require severe refactoring so I added a condiitional skip for this very test when running on win32. Out of the options I could think of this seems the most reasonable on.

With these three commits I now get a clean pytest run on Windows (with explicit skipping of the redownload test in the log).

Please verify that the tests function as before on your prefered platforms and that you are fine with the modified CLI tests.