### PR TITLE
feat: Adds `off_budget` argument to multiple methods to filter by `off_budget` status

### DIFF
--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -511,8 +511,7 @@ def test_get_transactions_with_cleared_filter(session):
         assert t.cleared
 
 
-def test_get_transactions_with_offbudget_filter(session):
-    """Test get_transactions filtering by off-budget accounts."""
+def test_get_transactions_with_of_budget_filter(session):
     on_budget_acct = create_account(session, "On Budget Account", off_budget=False)
     off_budget_acct = create_account(session, "Off Budget Account", off_budget=True)
 


### PR DESCRIPTION
Adds an optional `off_budget` parameter to the `get_transactions()` method to filter transactions based on whether they belong to off-budget or on-budget accounts.

This addresses the issue where users needed to distinguish between off-budget and on-budget transactions in their automations, as transactions from both types of accounts were being mixed together in results.

Resolves #154