### PR TITLE
feat: Support category and budget notes.

### DIFF
--- a/actual/database.py
+++ b/actual/database.py
@@ -297,7 +297,7 @@ class Accounts(BaseModel, table=True):
 
     @property
     def notes(self) -> str | None:
-        """Returns notes for the account. If none are present, returns `None`."""
+        """Returns notes for the account. If none is present, returns `None`."""
         return object_session(self).scalar(select(Notes.note).where(Notes.id == f"account-{self.id}"))
 
     @notes.setter
@@ -371,6 +371,16 @@ class Categories(BaseModel, table=True):
             )
         )
         return cents_to_decimal(value)
+
+    @property
+    def notes(self) -> str | None:
+        """Returns notes for the category. If none is present, returns `None`."""
+        return object_session(self).scalar(select(Notes.note).where(Notes.id == self.id))
+
+    @notes.setter
+    def notes(self, note: str | None) -> None:
+        """Set the note for the category as a string."""
+        object_session(self).merge(Notes(id=self.id, note=note))
 
 
 class CategoryGroups(BaseModel, table=True):
@@ -905,6 +915,18 @@ class BaseBudgets(BaseModel):
             )
         )
         return cents_to_decimal(value)
+
+    @property
+    def notes(self) -> str | None:
+        """Returns notes for the budget. If none is present, returns `None`."""
+        budget_id = f"budget-{self.get_date().strftime('%Y-%m')}"
+        return object_session(self).scalar(select(Notes.note).where(Notes.id == budget_id))
+
+    @notes.setter
+    def notes(self, note: str | None) -> None:
+        """Set the note for the budget as a string."""
+        budget_id = f"budget-{self.get_date().strftime('%Y-%m')}"
+        object_session(self).merge(Notes(id=budget_id, note=note))
 
 
 class ReflectBudgets(BaseBudgets, table=True):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -7,10 +7,11 @@ from datetime import date, timedelta
 import pytest
 
 from actual import Actual, ActualError, reflect_model
-from actual.database import Notes, Transactions, ZeroBudgetMonths
+from actual.database import Transactions, ZeroBudgetMonths
 from actual.exceptions import ActualInvalidOperationError
 from actual.queries import (
     create_account,
+    create_budget,
     create_rule,
     create_schedule,
     create_schedule_config,
@@ -323,12 +324,31 @@ def test_rollback(session):
 
 
 def test_model_notes(session):
+    # Account notes
     account_with_note = create_account(session, "Bank 1")
     account_without_note = create_account(session, "Bank 2")
-    session.add(Notes(id=f"account-{account_with_note.id}", note="My note"))
+    account_with_note.notes = "My note"
     session.commit()
     assert account_with_note.notes == "My note"
     assert account_without_note.notes is None
+    account_with_note.notes = None
+    assert account_with_note.notes is None
+    # Category notes
+    category_with_note = get_or_create_category(session, "Groceries")
+    category_without_note = get_or_create_category(session, "Transportation")
+    category_with_note.notes = "Spending on groceries."
+    session.commit()
+    assert category_with_note.notes == "Spending on groceries."
+    assert category_without_note.notes is None
+    account_with_note.notes = None
+    assert account_with_note.notes is None
+    # Budget notes
+    budget = create_budget(session, datetime.date.today(), category_with_note)
+    budget.notes = "My budget"
+    session.commit()
+    assert budget.notes == "My budget"
+    budget.notes = None
+    assert budget.notes is None
 
 
 def test_default_imported_payee(session):


### PR DESCRIPTION
Allows you to query the category and budget notes via the API. 

Example:

```python
from actual import Actual
from actual.queries import get_categories, get_budgets

with Actual(base_url="http://localhost:5006", password="mypass", file="My Finances") as actual:
    categories = get_categories(actual.session)
    for category in categories:
        if category.notes:
            print(category.name, category.notes)
```

Closes #181 