### PR TITLE
Add off budget and on budget rule logic

### DIFF
--- a/actual/rules.py
+++ b/actual/rules.py
@@ -180,6 +180,8 @@ def condition_evaluation(
 ) -> bool:
     """Helper function to evaluate the condition based on the true_value, value found on the transaction, and the
     self_value, value defined on rule condition."""
+    from actual.queries import get_account  # lazy import to prevent circular issues
+
     if true_value is None:
         # short circuit as comparisons with NoneType are useless
         return False
@@ -235,13 +237,9 @@ def condition_evaluation(
         tags = re.findall(r"\#[\U00002600-\U000027BF\U0001f300-\U0001f64F\U0001f680-\U0001f6FF\w-]+", self_value)
         return any(tag in true_value for tag in tags)
     elif op == ConditionType.ON_BUDGET:
-        from actual.queries import get_account  # lazy import to prevent circular issues
-
         account = get_account(session, true_value)
         return account is not None and account.offbudget == 0
     elif op == ConditionType.OFF_BUDGET:
-        from actual.queries import get_account  # lazy import to prevent circular issues
-
         account = get_account(session, true_value)
         return account is not None and account.offbudget == 1
     else:
@@ -337,7 +335,7 @@ class Condition(pydantic.BaseModel):
         true_value = get_value(getattr(transaction, attr), self.type)
         self_value = self.get_value()
         # get inner session from object
-        session = transaction._sa_instance_state.session
+        session = transaction._sa_instance_state.session  # noqa
         return condition_evaluation(self.op, true_value, self_value, self.options, session=session)
 
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -423,9 +423,9 @@ def test_on_budget_condition(session):
     t = create_transaction(session, datetime.date(2024, 1, 1), acct, imported_payee="")
     condition = {"type": "id", "field": "acct", "op": "onBudget", "value": None}
     cond = Condition.model_validate(condition)
-    assert cond.run(t)
+    assert cond.run(t) is True
     acct.offbudget = 1
-    assert not cond.run(t)
+    assert cond.run(t) is False
 
 
 def test_off_budget_condition(session):
@@ -434,6 +434,6 @@ def test_off_budget_condition(session):
     t = create_transaction(session, datetime.date(2024, 1, 1), acct, imported_payee="")
     condition = {"type": "id", "field": "acct", "op": "offBudget", "value": None}
     cond = Condition.model_validate(condition)
-    assert cond.run(t)
+    assert cond.run(t) is True
     acct.offbudget = 0
-    assert not cond.run(t)
+    assert cond.run(t) is False


### PR DESCRIPTION
# Summary

Updated logic so rules can handle the offBudget and onBudget account condition. The exact condition is used in the test case.

## Motivation

offBudget and onBudget account rule was failing.

## Server source code

Excerpt from line 403 of [condition.ts](https://github.com/actualbudget/actual/blob/master/packages/loot-core/src/server/rules/condition.ts#L403):

```typescript
      case 'onBudget':
        if (!object._account) {
          return false;
        }

        return object._account.offbudget === 0;

      case 'offBudget':
        if (!object._account) {
          return false;
        }

        return object._account.offbudget === 1;
```