### PR TITLE
fix: Correctly retrieve transactions when running rules.

### DIFF
--- a/actual/__init__.py
+++ b/actual/__init__.py
@@ -601,7 +601,7 @@ class Actual(ActualServer):
     def run_rules(self, transactions: list[Transactions] | None = None):
         """Runs all the stored rules on the database on all transactions, without any filters."""
         if transactions is None:
-            transactions = get_transactions(self.session, is_parent=True)
+            transactions = get_transactions(self.session)
         ruleset = get_ruleset(self.session)
         ruleset.run(transactions)
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -3,12 +3,14 @@ import uuid
 
 import pytest
 
-from actual import ActualError
+from actual import Actual, ActualError
 from actual.exceptions import ActualSplitTransactionError
 from actual.queries import (
     create_account,
     create_category,
     create_payee,
+    create_rule,
+    create_splits,
     create_transaction,
 )
 from actual.rules import (
@@ -437,3 +439,34 @@ def test_off_budget_condition(session):
     assert cond.run(t) is True
     acct.offbudget = 0
     assert cond.run(t) is False
+
+
+def test_run_rules(session, mocker):
+    # create basic items
+    acct = create_account(session, "Bank")
+    cat = create_category(session, "Food", "Expenses")
+    source_payee = create_payee(session, "Source payee")
+    target_payee = create_payee(session, "Target payee")
+    today = datetime.date.today()
+    t1 = create_transaction(session, today, acct, source_payee, notes="foo", category=cat)
+    splits = [
+        create_transaction(session, today, acct, source_payee, notes="foobar", category=cat),
+        create_transaction(session, today, acct, source_payee, notes="bar", category=cat),
+    ]
+    t_splits = create_splits(session, splits)
+    # create rule
+    condition = Condition(field="notes", op="contains", value="foo")
+    action = Action(field="description", value=target_payee)
+    rule = Rule(conditions=[condition], actions=[action], operation="all")
+    create_rule(session, rule)
+    # run rules via the API
+    mocker.patch("actual.Actual.validate")
+    actual = Actual(token="foobar")
+    actual._session = session
+    actual.run_rules()
+    session.commit()
+    # assert results are correct
+    assert t1.payee == target_payee
+    assert splits[0].payee == target_payee
+    assert splits[1].payee == source_payee
+    assert t_splits.payee is None


### PR DESCRIPTION
Aligns behaviour with the Actual UI when running rules against split transactions using the `run_rules` method.

Reported by @JaxOfDiamonds.

Reworks some of the points discussed in https://github.com/bvanelli/actualpy/discussions/186, where the rules didn't run correctly when using `run_rules`.