### PR TITLE
fix: Fix create schedule not inserting the next scheduled date.

### DIFF
--- a/actual/database.py
+++ b/actual/database.py
@@ -674,7 +674,7 @@ class SchedulesJsonPaths(SQLModel, table=True):
     date: str | None = Field(default=None, sa_column=Column("date", Text))
 
 
-class SchedulesNextDate(SQLModel, table=True):
+class SchedulesNextDate(BaseModel, table=True):
     __tablename__ = "schedules_next_date"
 
     id: str = Field(..., sa_column=Column("id", Text, primary_key=True))

--- a/actual/queries.py
+++ b/actual/queries.py
@@ -27,6 +27,7 @@ from actual.database import (
     ReflectBudgets,
     Rules,
     Schedules,
+    SchedulesNextDate,
     Tags,
     Transactions,
     ZeroBudgetMonths,
@@ -1222,6 +1223,25 @@ def create_schedule(
         rule=rule,
     )
     s.add(schedule)
+    # Compute and insert the next date row, matching upstream behavior
+    if isinstance(date, Schedule):
+        next_dates = date.xafter(date.start, count=1)
+        next_date = next_dates[0] if next_dates else date.start
+    elif isinstance(date, datetime.datetime):
+        next_date = date.date()
+    else:
+        next_date = date
+    next_date_int = date_to_int(next_date)
+    now_ts = current_timestamp()
+    next_date_row = SchedulesNextDate(
+        id=str(uuid.uuid4()),
+        schedule_id=schedule_id,
+        local_next_date=next_date_int,
+        local_next_date_ts=now_ts,
+        base_next_date=next_date_int,
+        base_next_date_ts=now_ts,
+    )
+    s.add(next_date_row)
     return schedule
 
 

--- a/actual/queries.py
+++ b/actual/queries.py
@@ -1225,7 +1225,7 @@ def create_schedule(
     s.add(schedule)
     # Compute and insert the next date row, matching upstream behavior
     if isinstance(date, Schedule):
-        next_dates = date.xafter(date.start, count=1)
+        next_dates = date.xafter()
         next_date = next_dates[0] if next_dates else date.start
     elif isinstance(date, datetime.datetime):
         next_date = date.date()

--- a/actual/utils/conversions.py
+++ b/actual/utils/conversions.py
@@ -77,7 +77,7 @@ def month_range(month: datetime.date) -> tuple[datetime.date, datetime.date]:
 
 def current_timestamp() -> int:
     """Returns the current timestamp in milliseconds, using UTC time."""
-    return int(datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).timestamp() * 1000)
+    return int(datetime.datetime.now(datetime.timezone.utc).timestamp() * 1000)
 
 
 def cents_to_decimal(amount: int | None) -> decimal.Decimal:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "types-python-dateutil",
     "types-PyYAML",
     "docker>=7.1.0",
+    "freezegun",
 ]
 docs = [
     "mkdocs==1.6.1",

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -572,13 +572,17 @@ def test_schedule_populates_next_date(session, frozen_today, start_date, expecte
     assert rows[0].local_next_date_ts == rows[0].base_next_date_ts
 
 
-def test_schedule_populates_next_date_simple_date(session):
-    schedule = create_schedule(session, datetime.date(2025, 6, 15), 100.0, name="simple_date_test")
+@pytest.mark.parametrize(
+    "start_date, expected_next_date",
+    [(datetime.date(2025, 6, 15), 20250615), (datetime.datetime(2025, 6, 15), 20250615)],
+)
+def test_schedule_populates_next_date_simple_date(session, start_date, expected_next_date):
+    schedule = create_schedule(session, start_date, 100.0, name="simple_date_test")
     session.flush()
     rows = session.exec(select(SchedulesNextDate).where(SchedulesNextDate.schedule_id == schedule.id)).all()
     assert len(rows) == 1
-    assert rows[0].local_next_date == 20250615
-    assert rows[0].base_next_date == 20250615
+    assert rows[0].local_next_date == expected_next_date
+    assert rows[0].base_next_date == expected_next_date
 
 
 def test_get_transactions_with_cleared_filter(session):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -5,9 +5,10 @@ import warnings
 from datetime import date, timedelta
 
 import pytest
+from sqlmodel import select
 
 from actual import Actual, ActualError, reflect_model
-from actual.database import Transactions, ZeroBudgetMonths
+from actual.database import SchedulesNextDate, Transactions, ZeroBudgetMonths
 from actual.exceptions import ActualInvalidOperationError
 from actual.queries import (
     create_account,
@@ -545,6 +546,28 @@ def test_schedule_config(session):
         create_schedule_config(today, end_mode="on_date")
     with pytest.raises(ActualError, match="the end_occurrences must be provided"):
         create_schedule_config(today, end_mode="after_n_occurrences")
+
+
+def test_schedule_populates_next_date(session):
+    config = create_schedule_config(datetime.date(2025, 10, 11))
+    schedule = create_schedule(session, config, 500.0, name="next_date_test")
+    session.flush()
+    rows = session.exec(select(SchedulesNextDate).where(SchedulesNextDate.schedule_id == schedule.id)).all()
+    assert len(rows) == 1
+    assert rows[0].local_next_date == 20251011
+    assert rows[0].base_next_date == 20251011
+    assert rows[0].local_next_date_ts is not None
+    assert rows[0].base_next_date_ts is not None
+    assert rows[0].local_next_date_ts == rows[0].base_next_date_ts
+
+
+def test_schedule_populates_next_date_simple_date(session):
+    schedule = create_schedule(session, datetime.date(2025, 6, 15), 100.0, name="simple_date_test")
+    session.flush()
+    rows = session.exec(select(SchedulesNextDate).where(SchedulesNextDate.schedule_id == schedule.id)).all()
+    assert len(rows) == 1
+    assert rows[0].local_next_date == 20250615
+    assert rows[0].base_next_date == 20250615
 
 
 def test_get_transactions_with_cleared_filter(session):

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -5,6 +5,7 @@ import warnings
 from datetime import date, timedelta
 
 import pytest
+from freezegun import freeze_time
 from sqlmodel import select
 
 from actual import Actual, ActualError, reflect_model
@@ -548,14 +549,24 @@ def test_schedule_config(session):
         create_schedule_config(today, end_mode="after_n_occurrences")
 
 
-def test_schedule_populates_next_date(session):
-    config = create_schedule_config(datetime.date(2025, 10, 11))
-    schedule = create_schedule(session, config, 500.0, name="next_date_test")
-    session.flush()
+@pytest.mark.parametrize(
+    "frozen_today, start_date, expected_next_date",
+    [
+        # today is before the start date, so next date is the start date
+        ("2025-10-01", datetime.date(2025, 10, 11), 20251011),
+        # today is after the start date, so next date is the next monthly occurrence
+        ("2025-11-01", datetime.date(2025, 10, 11), 20251111),
+    ],
+)
+def test_schedule_populates_next_date(session, frozen_today, start_date, expected_next_date):
+    with freeze_time(frozen_today):
+        config = create_schedule_config(start_date)
+        schedule = create_schedule(session, config, 500.0, name="next_date_test")
+        session.flush()
     rows = session.exec(select(SchedulesNextDate).where(SchedulesNextDate.schedule_id == schedule.id)).all()
     assert len(rows) == 1
-    assert rows[0].local_next_date == 20251011
-    assert rows[0].base_next_date == 20251011
+    assert rows[0].local_next_date == expected_next_date
+    assert rows[0].base_next_date == expected_next_date
     assert rows[0].local_next_date_ts is not None
     assert rows[0].base_next_date_ts is not None
     assert rows[0].local_next_date_ts == rows[0].base_next_date_ts


### PR DESCRIPTION
`create_schedule` creates the schedule and its rule/conditions correctly, but never inserts a row into the `schedules_next_date` table. The Actual frontend requires this row to compute and display the next occurrence date. Without it, the Next Date column is blank and the frontend crashes when attempting to edit the date field.

Here is the reference implementation from Actual: https://github.com/actualbudget/actual/blob/c0c2d1630ede6d58347af9e6a194dfa701f1fa37/packages/loot-core/src/server/schedules/app.ts#L288-L295

Closes #193 