### PR TITLE
fix: Fix rule's null value comparisons for is and isNot

### DIFF
--- a/actual/rules.py
+++ b/actual/rules.py
@@ -183,7 +183,11 @@ def condition_evaluation(
     from actual.queries import get_account  # lazy import to prevent circular issues
 
     if true_value is None:
-        # short circuit as comparisons with NoneType are useless
+        if op == ConditionType.IS:
+            return self_value is None
+        elif op == ConditionType.IS_NOT:
+            return self_value is not None
+        # short circuit as other comparisons with NoneType are useless
         return False
     if isinstance(options, dict):
         # short circuit if the transaction should be and in/outflow but it isn't

--- a/actual/rules.py
+++ b/actual/rules.py
@@ -164,6 +164,8 @@ def get_value(
     elif value_type is ValueType.BOOLEAN:
         return int(value)  # database accepts 0 or 1
     elif value_type in (ValueType.STRING, ValueType.IMPORTED_PAYEE):
+        if value is None:
+            return ""
         if isinstance(value, list):
             return [get_value(v, value_type) for v in value]
         else:

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -50,6 +50,16 @@ def test_category_rule(session):
     assert condition.run(t) is False
 
 
+def test_category_is_nothing_rule(session):
+    acct = create_account(session, "Bank")
+    cat = create_category(session, "Misc", "Expenses")
+    t = create_transaction(session, datetime.date(2024, 1, 1), acct, category=cat)
+    # "description is nothing" should match a transaction without payee
+    assert Condition(field="description", op="is", value=None).run(t) is True
+    # "description is not nothing" should not match an uncategorized transaction
+    assert Condition(field="description", op="isNot", value=None).run(t) is False
+
+
 def test_datetime_rule(session):
     acct = create_account(session, "Bank")
     t = create_transaction(session, datetime.date(2024, 1, 1), acct, "")

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -50,7 +50,7 @@ def test_category_rule(session):
     assert condition.run(t) is False
 
 
-def test_category_is_nothing_rule(session):
+def test_payee_is_nothing_rule(session):
     acct = create_account(session, "Bank")
     cat = create_category(session, "Misc", "Expenses")
     t = create_transaction(session, datetime.date(2024, 1, 1), acct, category=cat)
@@ -58,6 +58,16 @@ def test_category_is_nothing_rule(session):
     assert Condition(field="description", op="is", value=None).run(t) is True
     # "description is not nothing" should not match an uncategorized transaction
     assert Condition(field="description", op="isNot", value=None).run(t) is False
+
+
+def test_notes_is_nothing_rule(session):
+    acct = create_account(session, "Bank")
+    t = create_transaction(session, datetime.date(2024, 1, 1), acct, notes=None)
+    # null notes should match "notes is nothing" (empty string), mirroring JS null -> "" coercion
+    assert Condition(field="notes", op="is", value="").run(t) is True
+    assert Condition(field="notes", op="isNot", value="").run(t) is False
+    # "notes contains foo" should not match null notes
+    assert Condition(field="notes", op="contains", value="foo").run(t) is False
 
 
 def test_datetime_rule(session):
@@ -204,7 +214,8 @@ def test_invalid_inputs():
         Action(field="notes", op="set-split-amount", value="foo").run(None)  # noqa: use None instead of transaction
     with pytest.raises(ActualError):
         condition_evaluation(None, "foo", "foo")  # noqa: use None instead of transaction
-    assert Condition(field="notes", op="is", value=None).get_value() is None  # noqa: handle when value is None
+    # null strings coerce to ""
+    assert Condition(field="notes", op="is", value=None).get_value() == ""
 
 
 def test_value_type_condition_validation():


### PR DESCRIPTION
The JS implementation can be seem on the file [condition.ts](https://github.com/actualbudget/actual/blob/29275a573d247d305f4fb5217792a8ef616aee23/packages/loot-core/src/server/rules/condition.ts). On Actual rules, most `None` evaluations will use the guard:

```js
if (fieldValue == null) {
    return false;
}
```

When using `is` and `isNot` comparing with `None` values, there is an exception since it uses `fieldValue === this.value` and `fieldValue !== this.value`. We should allow the comparison to evaluate with the nullable field instead.

Another bug fix was comparing a null to a string object. There is a specific guard for this behavior:

```js
if (type === 'string') {
    fieldValue ??= '';
}
```

Here, the correct option is to convert both sides to an empty string, then use the compare function instead.

Closes #197 