### PR TITLE
Only include parent transactions when matching during reconciliation

### DIFF
--- a/actual/queries.py
+++ b/actual/queries.py
@@ -229,9 +229,13 @@ def match_transaction(
         if imported_transaction:
             return imported_transaction  # noqa
     # if not matched, look 7 days ahead and 7 days back when fuzzy matching
-    query = _transactions_base_query(
-        s, date - datetime.timedelta(days=7), date + datetime.timedelta(days=8), account=account
-    ).where(col(Transactions.amount) == round(amount * 100))
+    query = (
+        _transactions_base_query(
+            s, date - datetime.timedelta(days=7), date + datetime.timedelta(days=8), account=account
+        )
+        .where(col(Transactions.amount) == round(amount * 100))
+        .where(Transactions.is_child == 0)
+    )
     results: list[Transactions] = s.exec(query).all()  # noqa
     # filter out the ones that were already matched
     if already_matched:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -190,6 +190,46 @@ def test_reconcile_transaction_update(session):
     assert reconciled.notes == "New notes"
 
 
+def test_reconcile_with_split(session):
+    create_account(session, "Bank")
+
+    # Create a fine dining tx which is split to 1200 and 120, a grand total of 1320 for
+    # the actual parent tx
+    dining = create_transaction(session, today, "Bank", category="Dining", amount=-1200.0)
+    taxes = create_transaction(session, today, "Bank", category="Taxes", amount=-120.0)
+    create_splits(session, [dining, taxes], notes="Dining")
+    session.commit()
+
+    # Run a reconcile for a 1200 tx, it should not match the 1200-child but rather be created
+    # as a new tx
+    rent_payment = reconcile_transaction(
+        session,
+        today + timedelta(days=1),
+        "Bank",
+        category="Rent",
+        amount=-1200,
+        notes="New notes",
+        imported_id="unique",
+    )
+    assert rent_payment.id != dining.id
+    session.commit()
+
+    # Run another reconcile for 1200 and ensure that it matched the right tx
+    assert (
+        reconcile_transaction(
+            session,
+            today + timedelta(days=1),
+            "Bank",
+            category="Rent",
+            amount=-1200,
+            notes="New notes",
+            imported_id="unique",
+        ).id
+        == rent_payment.id
+    )
+    session.commit()
+
+
 def test_create_splits(session):
     bank = create_account(session, "Bank")
     t = create_transaction(session, today, bank, category="Dining", amount=-10.0)


### PR DESCRIPTION
When doing fuzzy matching for reconciliation the current version includes child transactions (ie splits) when matching which makes no sense and results in incorrect matches. For instance a 1320 transactions which has been split into 1200+120 should only match the total 1320 and not the subs 1200 or 120.

The fix is simple, a condition for is_child==0 in the initial quere, have also supplied a test case.