### PR TITLE
fix: Increase default httpx timeout and expose timeout parameter (#202)

### DIFF
--- a/actual/__init__.py
+++ b/actual/__init__.py
@@ -124,7 +124,7 @@ class Actual(ActualServer):
                           https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.__init__)
         :param extra_headers: Additional headers to be attached to each request to the Actual server.
         :param timeout: Timeout in seconds applied to all HTTP requests. Set to `None` to disable. Accepts a float or
-                        an [httpx.Timeout][httpx.Timeout] for fine-grained control. Defaults to 60 seconds.
+                        an `httpx.Timeout` object for fine-grained control. Defaults to 60 seconds.
         """
         super().__init__(base_url, token, password, bootstrap, cert, extra_headers, timeout)
         self._file: RemoteFileListDTO | None = None

--- a/actual/__init__.py
+++ b/actual/__init__.py
@@ -14,6 +14,7 @@ from collections.abc import Sequence
 from os import PathLike
 from typing import IO
 
+import httpx
 from sqlalchemy.engine import Engine
 from sqlmodel import MetaData, Session, create_engine
 
@@ -71,6 +72,7 @@ class Actual(ActualServer):
         bootstrap: bool = False,
         sa_kwargs: dict | None = None,
         extra_headers: dict[str, str] | None = None,
+        timeout: float | httpx.Timeout | None = 60.0,
     ):
         """
         Parts of the implementation are [available at the following file.](
@@ -120,9 +122,11 @@ class Actual(ActualServer):
                           by default), `autocommit` (disabled by default). For a list of all parameters, check the
                           [SQLAlchemy documentation.](
                           https://docs.sqlalchemy.org/en/20/orm/session_api.html#sqlalchemy.orm.Session.__init__)
-        :param extra_headers: Additional headers to be attached to each request to the Actual server
+        :param extra_headers: Additional headers to be attached to each request to the Actual server.
+        :param timeout: Timeout in seconds applied to all HTTP requests. Set to `None` to disable. Accepts a float or
+                        an [httpx.Timeout][httpx.Timeout] for fine-grained control. Defaults to 60 seconds.
         """
-        super().__init__(base_url, token, password, bootstrap, cert, extra_headers)
+        super().__init__(base_url, token, password, bootstrap, cert, extra_headers, timeout)
         self._file: RemoteFileListDTO | None = None
         self._data_dir: pathlib.Path | None = pathlib.Path(data_dir) if data_dir else None
         self.engine: Engine | None = None

--- a/actual/api/__init__.py
+++ b/actual/api/__init__.py
@@ -65,7 +65,7 @@ class ActualServer:
                      as a string or as custom [ssl.SSLContext][ssl.SSLContext]. Set to `False` for no certificate check.
         :param extra_headers: Additional headers to be attached to each request to the Actual server.
         :param timeout: Timeout in seconds applied to all HTTP requests. Set to `None` to disable. Accepts a float or
-                        an [httpx.Timeout][httpx.Timeout] for fine-grained control. Defaults to 60 seconds.
+                        an `httpx.Timeout` object for fine-grained control. Defaults to 60 seconds.
         """
         self.api_url: str = base_url.rstrip("/")
         self._token: str | None = token

--- a/actual/api/__init__.py
+++ b/actual/api/__init__.py
@@ -54,15 +54,18 @@ class ActualServer:
         bootstrap: bool = False,
         cert: str | ssl.SSLContext | bool = True,
         extra_headers: dict[str, str] | None = None,
+        timeout: float | httpx.Timeout | None = 60.0,
     ):
         """
-        :param base_url: Url of the running Actual server
-        :param token: The token for authentication, if this is available (optional)
+        :param base_url: Url of the running Actual server.
+        :param token: The token for authentication, if this is available (optional).
         :param password: The password for authentication. It will be used on the .login() method to retrieve the token.
         :param bootstrap: if the server is not bootstrapped, bootstrap it with the password.
         :param cert: If a custom certificate should be used (e.g., self-signed certificate), its path can be provided
                      as a string or as custom [ssl.SSLContext][ssl.SSLContext]. Set to `False` for no certificate check.
-        :param extra_headers: Additional headers to be attached to each request to the Actual server
+        :param extra_headers: Additional headers to be attached to each request to the Actual server.
+        :param timeout: Timeout in seconds applied to all HTTP requests. Set to `None` to disable. Accepts a float or
+                        an [httpx.Timeout][httpx.Timeout] for fine-grained control. Defaults to 60 seconds.
         """
         self.api_url: str = base_url.rstrip("/")
         self._token: str | None = token
@@ -72,7 +75,9 @@ class ActualServer:
             verify = ssl.create_default_context()
             verify.load_verify_locations(cadata=cert)
         # todo: Rename this on the next breaking change
-        self._requests_session: httpx.Client = httpx.Client(base_url=self.api_url, headers=extra_headers, verify=verify)
+        self._requests_session: httpx.Client = httpx.Client(
+            base_url=self.api_url, headers=extra_headers, verify=verify, timeout=timeout
+        )
         if token is None and password is None and not self.is_open_id_owner_created():
             raise ValueError("Either provide a valid token or a password.")
         # already try to log in if the password was provided


### PR DESCRIPTION
## Summary

- The httpx client in `ActualServer` was created without an explicit `timeout`, so httpx's default 5s applied to every request — including `/sync/sync`. This caused intermittent `httpcore.ReadTimeout` errors on `actual.commit()` for users on slower servers or larger payloads (#202).
- The Node.js Actual client imposes no timeout at all on the binary sync endpoint, so 5s is materially stricter than upstream.
- This PR raises the default to 60s and exposes a `timeout` constructor parameter on both `ActualServer` and `Actual`. Accepts a float, `None` (disabled), or an `httpx.Timeout` object for fine-grained control.

Closes #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)