### PR TITLE
Explicitly set terminal width to 120 in test to ensure that no truncation occurs

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,7 @@ from tests.conftest import ACTUAL_SERVER_INTEGRATION_VERSIONS
 
 runner = CliRunner()
 server_version = ACTUAL_SERVER_INTEGRATION_VERSIONS[-1]  # use latest version
+os.environ["COLUMNS"] = "120"
 
 
 def base_dataset(actual: Actual, budget_name: str = "Test", encryption_password: str | None = None):


### PR DESCRIPTION
test_envelope_budget and test_tracking_budget in test_cli have been failing for a long time on Windows due to the output being truncated since pytest defaults to a 80 character wide terminal.

This PR sets the terminal width to 120 to ensure that it is consistent no matter which underlying OS/terminal is used resulting in all test cases passing cleanly again.