### PR TITLE
test: import Result from typer.testing instead of click

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,10 +4,9 @@ import os
 import pathlib
 
 import pytest
-from click.testing import Result
 from testcontainers.core.container import DockerContainer
 from testcontainers.core.waiting_utils import wait_for_logs
-from typer.testing import CliRunner
+from typer.testing import CliRunner, Result
 
 from actual import Actual, __version__
 from actual.cli.config import Config, default_config_path


### PR DESCRIPTION
## Summary

`tests/test_cli.py` imported `Result` from `click.testing` purely as a return-type annotation for the local `invoke()` helper. The project never declared `click` as a direct dependency — it was only present transitively because `typer` (pulled in via the `cli` extra) used to depend on it. Recent typer releases dropped the `click` dependency, so fresh CI installs no longer get `click`, and the import fails at test collection time, breaking the pipeline.

Switching to `from typer.testing import Result` fixes this without adding a new dependency. `typer.testing` re-exposes `Result` across the entire `typer>=0.12.0` range declared in `pyproject.toml`:

- typer 0.12.0 → `click.testing.Result` (when click was still a transitive dep)
- typer 0.26.x → `typer._click.testing.Result` (typer now vendors click internally)

Verified empirically in both environments.

## Test plan

- [ ] CI pipeline (`test.yaml`) passes on this branch
- [ ] `tests/test_cli.py` imports resolve without `click` installed

---
_Generated by [Claude Code](https://claude.ai/code/session_011HAZfKDux836jRFmrFTsAF)_