### PR TITLE
refactor: Enable a few more mypy checks and fix related typing issues.

### DIFF
--- a/actual/__init__.py
+++ b/actual/__init__.py
@@ -12,7 +12,7 @@ import warnings
 import zipfile
 from collections.abc import Sequence
 from os import PathLike
-from typing import IO
+from typing import IO, cast
 
 import httpx
 from sqlalchemy.engine import Engine
@@ -34,6 +34,7 @@ from actual.database import (
 from actual.exceptions import (
     ActualBankSyncError,
     ActualDecryptionError,
+    ActualEncryptionError,
     ActualError,
     InvalidZipFile,
     UnknownFileId,
@@ -304,7 +305,7 @@ class Actual(ActualServer):
         # reset group id, as file cannot be synced anymore
         self.file.group_id = None
 
-    def cleanup(self):
+    def cleanup(self) -> None:
         """
         Cleans up the database from all deleted transactions, message caches and runs a `VACUUM`.
 
@@ -381,13 +382,13 @@ class Actual(ActualServer):
         self._master_key = create_key_buffer(encryption_password, salt)
         # encrypt binary data with
         encrypted = encrypt(self.file.encrypt_key_id, self._master_key, self.export_data())
-        binary_data = io.BytesIO(base64.b64decode(encrypted["value"]))
-        encryption_meta = encrypted["meta"]
+        binary_data = io.BytesIO(base64.b64decode(encrypted.value))
+        encryption_meta = encrypted.meta
         self.reset_user_file(self.file.file_id)
         self.upload_user_file(binary_data.getvalue(), self.file.file_id, self.file.name, encryption_meta)
         self.set_file(self.file.file_id)
 
-    def upload_budget(self):
+    def upload_budget(self) -> None:
         """
         Uploads the current file to the Actual server.
 
@@ -396,21 +397,24 @@ class Actual(ActualServer):
         """
         if not self._data_dir:
             raise UnknownFileId("No current file loaded.")
-        if not self._file:
+        file = self._file
+        if not file:
             file_id = str(uuid.uuid4())
             metadata = self.get_metadata()
             budget_name = metadata.get("budgetName", "My Finances")
-            self._file = RemoteFileListDTO(name=budget_name, fileId=file_id, groupId=None, deleted=0, encryptKeyId=None)
+            file = RemoteFileListDTO(name=budget_name, fileId=file_id, groupId=None, deleted=0, encryptKeyId=None)
         binary_data = io.BytesIO()
         with zipfile.ZipFile(binary_data, "a", zipfile.ZIP_DEFLATED, False) as z:
             z.write(self.data_dir / "db.sqlite", "db.sqlite")
             z.write(self.data_dir / "metadata.json", "metadata.json")
         # we have to first upload the user file so the reference id can be used to generate a new encryption key
-        self.upload_user_file(binary_data.getvalue(), self._file.file_id, self._file.name)
+        self.upload_user_file(binary_data.getvalue(), file.file_id, file.name)
         # reset local file id to retrieve the grouping id
-        self.set_file(self._file.file_id)
+        self.set_file(file.file_id)
         # encrypt the file and re-upload
-        if self._encryption_password or self._master_key or self._file.encrypt_key_id:
+        if self._encryption_password or self._master_key or file.encrypt_key_id:
+            if not self._encryption_password:
+                raise ActualEncryptionError("Budget is encrypted but password was not provided")
             self.encrypt(self._encryption_password)
 
     def reupload_budget(self):
@@ -422,7 +426,7 @@ class Actual(ActualServer):
         **This operation can be destructive**, so make sure you generate a copy before attempting to re-upload
         your budget.
         """
-        self.reset_user_file(self._file.file_id)
+        self.reset_user_file(self.file.file_id)
         self.update_metadata({"groupId": None})  # since we don't know what the new group id will be
         self.upload_budget()
 
@@ -476,7 +480,8 @@ class Actual(ActualServer):
     def get_metadata(self) -> dict:
         """Gets the content of the `metadata.json` file."""
         metadata_file = self.data_dir / "metadata.json"
-        return json.loads(metadata_file.read_text())
+        # Here, we trust the metadata will have the correct format
+        return cast(dict, json.loads(metadata_file.read_text()))
 
     def update_metadata(self, patch: dict):
         """
@@ -580,7 +585,7 @@ class Actual(ActualServer):
         zip_file.extractall(self._data_dir)
         self.create_engine()
 
-    def create_engine(self):
+    def create_engine(self) -> None:
         """Internally creates the engine for the database, and loads the reflected metadata."""
         self.engine = create_engine(f"sqlite:///{self._data_dir}/db.sqlite")
         self._database_metadata = reflect_model(self.engine)

--- a/actual/api/__init__.py
+++ b/actual/api/__init__.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import datetime
 import json
 import ssl
-from typing import Literal, overload
+from typing import Literal, cast, overload
 
 import httpx
 
@@ -15,6 +15,7 @@ from actual.api.models import (
     BankSyncStatusDTO,
     BankSyncTransactionResponseDTO,
     BootstrapInfoDTO,
+    EncryptMetaDTO,
     Endpoints,
     GetUserFileInfoDTO,
     InfoDTO,
@@ -130,7 +131,7 @@ class ActualServer:
             if not self.is_open_id_owner_created():
                 raise AuthorizationError("OpenID server is not set-up.")
 
-            with AuthCodeReceiver() as receiver:
+            with AuthCodeReceiver() as receiver:  # type: ignore[no-untyped-call]
                 redirect_url = f"http://localhost:{receiver.get_port()}"
                 response = self._requests_session.post(
                     Endpoints.LOGIN.value,
@@ -233,7 +234,11 @@ class ActualServer:
         return db.content
 
     def upload_user_file(
-        self, binary_data: bytes, file_id: str, file_name: str = "My Finances", encryption_meta: dict | None = None
+        self,
+        binary_data: bytes,
+        file_id: str,
+        file_name: str = "My Finances",
+        encryption_meta: EncryptMetaDTO | None = None,
     ) -> UploadUserFileDTO:
         """Uploads the binary data, which is a zip folder containing the `db.sqlite` and the `metadata.json`. If the
         file is encrypted, the encryption_meta has to be provided with fields `keyId`, `algorithm`, `iv` and `authTag`
@@ -245,7 +250,7 @@ class ActualServer:
             "Content-Type": "application/encrypted-file",
         }
         if encryption_meta:
-            base_headers["X-ACTUAL-ENCRYPT-META"] = json.dumps(encryption_meta)
+            base_headers["X-ACTUAL-ENCRYPT-META"] = encryption_meta.model_dump_json(by_alias=True)
         request = self._requests_session.post(
             Endpoints.UPLOAD_USER_FILE.value,
             content=binary_data,
@@ -333,8 +338,7 @@ class ActualServer:
             content=SyncRequest.serialize(request),
         )
         response.raise_for_status()
-        parsed_response = SyncResponse.deserialize(response.content)
-        return parsed_response  # noqa
+        return cast(SyncResponse, SyncResponse.deserialize(response.content))
 
     def login_methods(self) -> LoginMethodsDTO:
         """Returns login methods available for the user."""
@@ -349,7 +353,7 @@ class ActualServer:
         if response.status_code > 400:
             # here, it could be that the method returns 404 for an older version
             return False
-        return response.json()
+        return bool(response.json())
 
     def open_id_config(self, password: str) -> OpenIDConfigResponseDTO:
         """Gets the OpenID configuration for the server. You will need to provide the main password to access this

--- a/actual/api/__init__.py
+++ b/actual/api/__init__.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import datetime
-import json
 import ssl
 from typing import Literal, cast, overload
 
@@ -312,7 +311,7 @@ class ActualServer:
                 "fileId": file_id,
                 "keyId": key_id,
                 "keySalt": key_salt,
-                "testContent": json.dumps(test_content),
+                "testContent": test_content.model_dump_json(by_alias=True),
                 "token": self._token,
             },
         )

--- a/actual/api/bank_sync.py
+++ b/actual/api/bank_sync.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import decimal
 import enum
+import typing
 
 from pydantic import AliasChoices, BaseModel, Field
 
@@ -32,7 +33,7 @@ class BankSyncAccountDTO(BaseModel):
     available_balance: str = Field(..., alias="available-balance")
     balance_date: int = Field(..., alias="balance-date")
     transactions: list[BankSyncTransactionDTO]
-    holdings: list[dict]
+    holdings: list[dict[str, typing.Any]]
 
 
 class BankSyncAmount(BaseModel):

--- a/actual/budgets.py
+++ b/actual/budgets.py
@@ -280,7 +280,7 @@ class BaseBudget:
         return sum([c.accumulated_balance for c in self.category_groups], start=decimal.Decimal(0))
 
     @property
-    def spent(self):
+    def spent(self) -> decimal.Decimal:
         """
         Expenses for the current month.
 

--- a/actual/cli/config.py
+++ b/actual/cli/config.py
@@ -11,7 +11,7 @@ from actual import Actual
 console = Console()
 
 
-def default_config_path():
+def default_config_path() -> Path:
     return Path.home() / ".actualpy" / "config.yaml"
 
 
@@ -39,7 +39,7 @@ class Config(pydantic.BaseModel):
         default_factory=dict, description="Dict of configured budgets on CLI."
     )
 
-    def save(self):
+    def save(self) -> None:
         """Saves the current configuration to a file."""
         config_path = default_config_path()
         os.makedirs(config_path.parent, exist_ok=True)
@@ -48,7 +48,7 @@ class Config(pydantic.BaseModel):
             yaml.dump(self.model_dump(by_alias=True), file)
 
     @classmethod
-    def load(cls):
+    def load(cls) -> "Config":
         """Load the configuration file. If it doesn't exist, create a basic config."""
         config_path = default_config_path()
         if not config_path.exists():

--- a/actual/cli/main.py
+++ b/actual/cli/main.py
@@ -13,6 +13,7 @@ from actual import Actual
 from actual.budgets import EnvelopeBudget, TrackingBudget, get_budget_history
 from actual.cli.config import BudgetConfig, Config, OutputType, State
 from actual.cli.formatters import colored_number_format, decimal_format
+from actual.cli.models import AccountData, PayeeData, TransactionData
 from actual.queries import get_accounts, get_payees, get_transactions
 from actual.version import __version__
 
@@ -155,10 +156,12 @@ def accounts():
     Show all accounts.
     """
     # Mock data for demonstration purposes
-    accounts_data = []
+    accounts_data: list[AccountData] = []
     with config.actual() as actual:
         accounts_raw_data = get_accounts(actual.session)
         for account in accounts_raw_data:
+            if account.name is None:  # mypy check
+                continue
             accounts_data.append(
                 {
                     "name": account.name,
@@ -171,8 +174,8 @@ def accounts():
         table.add_column("Account Name", justify="left", style="cyan", no_wrap=True)
         table.add_column("Balance", justify="right", style="green")
 
-        for account in accounts_data:
-            table.add_row(account["name"], f"{account['balance']:.2f}")
+        for account_data in accounts_data:
+            table.add_row(account_data["name"], f"{account_data['balance']:.2f}")
 
         console.print(table)
     else:
@@ -184,7 +187,7 @@ def transactions():
     """
     Show all transactions.
     """
-    transactions_data = []
+    transactions_data: list[TransactionData] = []
     with config.actual() as actual:
         transactions_raw_data = get_transactions(actual.session)
         for transaction in transactions_raw_data:
@@ -206,14 +209,14 @@ def transactions():
         table.add_column("Category", justify="left", style="cyan")
         table.add_column("Amount", justify="right", style="green")
 
-        for transaction in transactions_data:
-            color = "green" if transaction["amount"] >= 0 else "red"
+        for transaction_data in transactions_data:
+            color = "green" if transaction_data["amount"] >= 0 else "red"
             table.add_row(
-                transaction["date"],
-                transaction["payee"],
-                transaction["notes"],
-                transaction["category"],
-                f"[{color}]{transaction['amount']:.2f}[/]",
+                transaction_data["date"],
+                transaction_data["payee"],
+                transaction_data["notes"],
+                transaction_data["category"],
+                f"[{color}]{transaction_data['amount']:.2f}[/]",
             )
 
         console.print(table)
@@ -226,10 +229,12 @@ def payees():
     """
     Show all payees.
     """
-    payees_data = []
+    payees_data: list[PayeeData] = []
     with config.actual() as actual:
         payees_raw_data = get_payees(actual.session)
         for payee in payees_raw_data:
+            if payee.name is None:  # mypy check
+                continue
             payees_data.append({"name": payee.name, "balance": round(float(payee.balance), 2)})
 
     if state.output == OutputType.table:
@@ -237,11 +242,11 @@ def payees():
         table.add_column("Name", justify="left", style="cyan", no_wrap=True)
         table.add_column("Balance", justify="right")
 
-        for payee in payees_data:
-            color = "green" if payee["balance"] >= 0 else "red"
+        for payee_data in payees_data:
+            color = "green" if payee_data["balance"] >= 0 else "red"
             table.add_row(
-                payee["name"],
-                f"[{color}]{payee['balance']:.2f}[/]",
+                payee_data["name"],
+                f"[{color}]{payee_data['balance']:.2f}[/]",
             )
         console.print(table)
     else:

--- a/actual/cli/main.py
+++ b/actual/cli/main.py
@@ -160,11 +160,9 @@ def accounts():
     with config.actual() as actual:
         accounts_raw_data = get_accounts(actual.session)
         for account in accounts_raw_data:
-            if account.name is None:  # mypy check
-                continue
             accounts_data.append(
                 {
-                    "name": account.name,
+                    "name": account.name or "",
                     "balance": float(account.balance),
                 }
             )
@@ -233,9 +231,7 @@ def payees():
     with config.actual() as actual:
         payees_raw_data = get_payees(actual.session)
         for payee in payees_raw_data:
-            if payee.name is None:  # mypy check
-                continue
-            payees_data.append({"name": payee.name, "balance": round(float(payee.balance), 2)})
+            payees_data.append({"name": payee.name or "", "balance": round(float(payee.balance), 2)})
 
     if state.output == OutputType.table:
         table = Table(title="Payees")

--- a/actual/cli/models.py
+++ b/actual/cli/models.py
@@ -1,0 +1,19 @@
+from typing import TypedDict
+
+
+class AccountData(TypedDict):
+    name: str
+    balance: float
+
+
+class TransactionData(TypedDict):
+    date: str
+    payee: str | None
+    notes: str
+    category: str | None
+    amount: float
+
+
+class PayeeData(TypedDict):
+    name: str
+    balance: float

--- a/actual/crypto.py
+++ b/actual/crypto.py
@@ -9,6 +9,7 @@ from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
+from actual.api.models import EncryptionTestDTO, EncryptMetaDTO
 from actual.exceptions import ActualDecryptionError
 
 
@@ -33,21 +34,21 @@ def create_key_buffer(password: str, key_salt: str) -> bytes:
     return kdf.derive(password.encode())
 
 
-def encrypt(key_id: str, master_key: bytes, plaintext: bytes) -> dict:
+def encrypt(key_id: str, master_key: bytes, plaintext: bytes) -> EncryptionTestDTO:
     """Encrypts a plaintext (actual database) using AES-GCM."""
     iv = os.urandom(12)
     encryptor = Cipher(algorithms.AES(master_key), modes.GCM(iv)).encryptor()
     value = encryptor.update(plaintext) + encryptor.finalize()
     auth_tag = encryptor.tag
-    return {
-        "value": base64.b64encode(value).decode(),
-        "meta": {
-            "keyId": key_id,
-            "algorithm": "aes-256-gcm",
-            "iv": base64.b64encode(iv).decode(),
-            "authTag": base64.b64encode(auth_tag).decode(),
-        },
-    }
+    return EncryptionTestDTO(
+        value=base64.b64encode(value).decode(),
+        meta=EncryptMetaDTO(
+            keyId=key_id,
+            algorithm="aes-256-gcm",
+            iv=base64.b64encode(iv).decode(),
+            authTag=base64.b64encode(auth_tag).decode(),
+        ),
+    )
 
 
 def decrypt(master_key: bytes, iv: bytes, ciphertext: bytes, auth_tag: bytes | None = None) -> bytes:
@@ -66,7 +67,7 @@ def decrypt_from_meta(master_key: bytes, ciphertext: bytes, encrypt_meta) -> byt
     return decrypt(master_key, iv, ciphertext, auth_tag)
 
 
-def make_test_message(key_id: str, key: bytes) -> dict:
+def make_test_message(key_id: str, key: bytes) -> EncryptionTestDTO:
     """Reference
     https://github.com/actualbudget/actual/blob/70e37c0119f4ba95ccf6549f0df4aac770f1bb8f/packages/loot-core/src/server/sync/make-test-message.ts#L10
     """

--- a/actual/database.py
+++ b/actual/database.py
@@ -18,7 +18,7 @@ import datetime
 import decimal
 import json
 from collections.abc import Sequence
-from typing import Optional, TypedDict
+from typing import Any, Optional, TypedDict, cast
 
 from sqlalchemy import MetaData, Table, engine, event, inspect
 from sqlalchemy.dialects.sqlite import insert
@@ -92,7 +92,9 @@ def get_class_from_reflected_table_name(metadata: MetaData, table_name: str) -> 
     return metadata.tables.get(table_name, None)
 
 
-def get_attribute_from_reflected_table_name(metadata: MetaData, table_name: str, column_name: str) -> Column | None:
+def get_attribute_from_reflected_table_name(
+    metadata: MetaData, table_name: str, column_name: str
+) -> Column[Any] | None:
     """
     Returns, based on the defined reflected model the corresponding and the SAColumn.
 
@@ -138,7 +140,9 @@ def get_attribute_by_table_name(table_name: str, column_name: str, reverse: bool
     return mapping.get(column_name)
 
 
-def apply_change(session: Session, table: Table, table_id: str, values: dict[Column, str | int | float | None]) -> None:
+def apply_change(
+    session: Session, table: Table, table_id: str, values: dict[Column[Any], str | int | float | None]
+) -> None:
     """
     This function upserts multiple changes into a table based on the `table_id` as the primary key.
 
@@ -239,7 +243,7 @@ class BaseModel(SQLModel):
                 changed_attributes.append(column)
         return changed_attributes
 
-    def delete(self):
+    def delete(self) -> None:
         """Deletes the model, by setting the `tombstone` attribute to 1. It is only possible to hard delete
         transactions by updating and re-uploading the downloaded budget."""
         if not hasattr(self, "tombstone"):
@@ -353,7 +357,7 @@ class Categories(BaseModel, table=True):
     sort_order: float | None = Field(default=None, sa_column=Column("sort_order", Float))
     tombstone: int | None = Field(default=None, sa_column=Column("tombstone", Integer, server_default=text("0")))
     goal_def: str | None = Field(default=None, sa_column=Column("goal_def", Text, server_default=text("null")))
-    template_settings: dict | None = Field(default=None, sa_column=Column("template_settings", JSON))
+    template_settings: dict[str, Any] | None = Field(default=None, sa_column=Column("template_settings", JSON))
 
     zero_budgets: "ZeroBudgets" = Relationship(
         back_populates="category",
@@ -543,7 +547,7 @@ class MessagesClock(SQLModel, table=True):
         """Gets the clock from JSON text to a dictionary with fields `timestamp` and `merkle`."""
         if self.clock is None:
             raise ValueError("Clock is not set")
-        return json.loads(self.clock)
+        return cast(dict, json.loads(self.clock))
 
     def set_clock(self, value: dict):
         """Sets the clock from a dictionary and stores it in the correct format."""
@@ -842,7 +846,7 @@ class Transactions(BaseModel, table=True):
         # Return the input value unmodified as this is a validator for the parent
         return v
 
-    def delete(self):
+    def delete(self) -> None:
         """Overload the delete() from the BaseModel so that we can properly delete any children splits
         as well. Otherwise things will not add up in the Actual GUI when calling delete() on a parent.
 

--- a/actual/exceptions.py
+++ b/actual/exceptions.py
@@ -71,6 +71,16 @@ class InvalidFile(ActualError):
     pass
 
 
+class ActualEncryptionError(ActualError):
+    """
+    The encryption for the file failed.
+
+    This will happen when you try to upload an encrypted file without providing a password.
+    """
+
+    pass
+
+
 class ActualDecryptionError(ActualError):
     """
     The decryption for the file failed.

--- a/actual/protobuf_models.py
+++ b/actual/protobuf_models.py
@@ -76,7 +76,7 @@ class HULC_Client:
         return str(self)
 
     @staticmethod
-    def random_client_id():
+    def random_client_id() -> str:
         """Creates a client id for the HULC request.
 
         Implementation copied [from the source code](
@@ -186,11 +186,16 @@ class SyncRequest(proto.Message):
             is_encrypted = False
             if master_key is not None:
                 encrypted_content = encrypt("", master_key, content)
+                # encrypt() always populates iv and auth_tag; the Optional is only for server responses
+                if encrypted_content.meta.iv is None or encrypted_content.meta.auth_tag is None:
+                    raise ActualDecryptionError(
+                        f"EncryptionTestDTO does not contain the required encryption data: {encrypted_content}"
+                    )
                 encrypted_data = EncryptedData(
                     {
-                        "iv": base64.b64decode(encrypted_content["meta"]["iv"]),
-                        "authTag": base64.b64decode(encrypted_content["meta"]["authTag"]),
-                        "data": base64.b64decode(encrypted_content["value"]),
+                        "iv": base64.b64decode(encrypted_content.meta.iv),
+                        "authTag": base64.b64decode(encrypted_content.meta.auth_tag),
+                        "data": base64.b64decode(encrypted_content.value),
                     }
                 )
                 content = EncryptedData.serialize(encrypted_data)

--- a/actual/rules.py
+++ b/actual/rules.py
@@ -8,7 +8,7 @@ import typing
 import unicodedata
 
 import pydantic
-from pydantic import model_serializer
+from pydantic import SerializerFunctionWrapHandler, model_serializer
 from sqlmodel import Session
 
 from actual.crypto import is_uuid
@@ -108,7 +108,11 @@ class ValueType(enum.Enum):
             # must be BOOLEAN
             return operation.value in ("is",)
 
-    def validate(self, value: int | list[str] | str | None, operation: ConditionType | None = None) -> bool:
+    def validate(
+        self,
+        value: int | list[str] | str | datetime.date | BetweenValue | Schedule | None,
+        operation: ConditionType | None = None,
+    ) -> bool:
         if isinstance(value, list) and operation in (ConditionType.ONE_OF, ConditionType.NOT_ONE_OF):
             return all(self.validate(v, None) for v in value)
         if value is None:
@@ -328,7 +332,7 @@ class Condition(pydantic.BaseModel):
         return f"'{self.field}' {self.op.value} {v}"
 
     @model_serializer(mode="wrap")
-    def serialize_model(self, handler) -> dict:
+    def serialize_model(self, handler: SerializerFunctionWrapHandler) -> typing.Any:
         """Returns valid dict for database insertion."""
         ret = handler(self)
         if not self.options:
@@ -342,7 +346,7 @@ class Condition(pydantic.BaseModel):
     def convert_value(self):
         if self.field in ("amount_inflow", "amount_outflow") and self.options is None:
             self.options = {self.field.split("_")[1]: True}
-            self.value = abs(self.value)
+            self.value = abs(self.value)  # type: ignore[arg-type]
             self.field = "amount"
         return self
 
@@ -425,7 +429,7 @@ class Action(pydantic.BaseModel):
         return f"{self.op.value} '{self.value}'"
 
     @model_serializer(mode="wrap")
-    def serialize_model(self, handler) -> dict:
+    def serialize_model(self, handler: SerializerFunctionWrapHandler) -> typing.Any:
         """Returns valid dict for database insertion."""
         ret = handler(self)
         if not self.options:

--- a/actual/schedules.py
+++ b/actual/schedules.py
@@ -20,7 +20,7 @@ from dateutil.rrule import (
     weekday,
     weekdays,
 )
-from pydantic import model_serializer
+from pydantic import SerializerFunctionWrapHandler, model_serializer
 
 from actual.utils.conversions import date_to_datetime, day_to_ordinal
 
@@ -212,10 +212,9 @@ class Schedule(pydantic.BaseModel):
         return f"Every {frequency}{target}{end}{move}"
 
     @model_serializer(mode="wrap")
-    def serialize_model(self, handler) -> dict:
+    def serialize_model(self, handler: SerializerFunctionWrapHandler) -> typing.Any:
         """Converts a schedule to a dict that can be used in a rule."""
-        ret = handler(self)
-        return ret
+        return handler(self)
 
     @pydantic.model_validator(mode="after")
     def validate_end_date(self):

--- a/actual/utils/title.py
+++ b/actual/utils/title.py
@@ -163,7 +163,7 @@ def convert_to_regexp(special_characters: list[str]):
     return [(re.compile(rf"\b{s}\b", re.IGNORECASE), s) for s in special_characters]
 
 
-def parse_match(match: str):
+def parse_match(match: str) -> str | None:
     first_character = match[0]
     if re.match(r"\s", first_character):
         return match[1:]
@@ -172,7 +172,7 @@ def parse_match(match: str):
     return match
 
 
-def replace_func(m: re.Match):
+def replace_func(m: re.Match[str]) -> str:
     lead, forced, lower, rest = m.groups()
     parsed_match = parse_match(m.group(0))
     if not parsed_match:
@@ -184,7 +184,7 @@ def replace_func(m: re.Match):
     return (lead or "") + (lower or forced or "").upper() + (rest or "")
 
 
-def title(title_str: str, custom_specials: list[str] | None = None):
+def title(title_str: str, custom_specials: list[str] | None = None) -> str:
     title_str = title_str.lower()
     title_str = regex.sub(replace_func, title_str)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,18 +105,29 @@ max-complexity = 18
 plugins = ["pydantic.mypy"]
 ## TODO: Work one by one until we can enable --strict mode for mypy.
 # disallow_any_generics = true
-# disallow_subclassing_any = true
-# disallow_untyped_calls = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
 # disallow_untyped_defs = true
 # disallow_incomplete_defs = true
-# check_untyped_defs = true
+check_untyped_defs = true
 disallow_untyped_decorators = true
 warn_redundant_casts = true
 warn_unused_ignores = true
-# warn_return_any = true
+warn_return_any = true
 no_implicit_reexport = true
 strict_equality = true
 
 [[tool.mypy.overrides]]
 module = ["proto", "proto.*", "testcontainers", "testcontainers.*"]
 ignore_missing_imports = true
+
+# Copied from microsoft-authentication-library-for-python, skip type checks.
+[[tool.mypy.overrides]]
+module = ["actual.utils.openid"]
+ignore_errors = true
+
+# `proto.Message` is typed as `Any` because of the `proto` ignore_missing_imports above.
+[[tool.mypy.overrides]]
+module = ["actual.protobuf_models"]
+disallow_subclassing_any = false
+warn_return_any = false

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -2,7 +2,7 @@ import base64
 
 import pytest
 
-from actual.api.models import EncryptionDTO, EncryptMetaDTO
+from actual.api.models import EncryptionDTO
 from actual.crypto import (
     create_key_buffer,
     decrypt,
@@ -28,10 +28,10 @@ def test_encrypt_decrypt():
     key = create_key_buffer("foo", "bar")
     string_to_encrypt = b"foobar"
     encrypted = encrypt("foo", key, string_to_encrypt)
-    decrypted_from_meta = decrypt_from_meta(key, base64.b64decode(encrypted.value), EncryptMetaDTO(**encrypted.meta))
+    decrypted_from_meta = decrypt_from_meta(key, base64.b64decode(encrypted.value), encrypted.meta)
     assert decrypted_from_meta == string_to_encrypt
     with pytest.raises(ActualDecryptionError):
-        decrypt_from_meta(key[::-1], base64.b64decode(encrypted.value), EncryptMetaDTO(**encrypted.meta))
+        decrypt_from_meta(key[::-1], base64.b64decode(encrypted.value), encrypted.meta)
 
 
 def test_encrypt_decrypt_message():

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -28,12 +28,10 @@ def test_encrypt_decrypt():
     key = create_key_buffer("foo", "bar")
     string_to_encrypt = b"foobar"
     encrypted = encrypt("foo", key, string_to_encrypt)
-    decrypted_from_meta = decrypt_from_meta(
-        key, base64.b64decode(encrypted["value"]), EncryptMetaDTO(**encrypted["meta"])
-    )
+    decrypted_from_meta = decrypt_from_meta(key, base64.b64decode(encrypted.value), EncryptMetaDTO(**encrypted.meta))
     assert decrypted_from_meta == string_to_encrypt
     with pytest.raises(ActualDecryptionError):
-        decrypt_from_meta(key[::-1], base64.b64decode(encrypted["value"]), EncryptMetaDTO(**encrypted["meta"]))
+        decrypt_from_meta(key[::-1], base64.b64decode(encrypted.value), EncryptMetaDTO(**encrypted.meta))
 
 
 def test_encrypt_decrypt_message():
@@ -53,9 +51,7 @@ def test_encrypt_decrypt_message():
 def test_create_test_message():
     key = create_key_buffer(make_salt(), make_salt())
     tm = make_test_message("", key)
-    dfm = decrypt(
-        key, base64.b64decode(tm["meta"]["iv"]), base64.b64decode(tm["value"]), base64.b64decode(tm["meta"]["authTag"])
-    )
+    dfm = decrypt(key, base64.b64decode(tm.meta.iv), base64.b64decode(tm.value), base64.b64decode(tm.meta.auth_tag))
     m = Message.deserialize(dfm)
     assert isinstance(m, Message)
 


### PR DESCRIPTION
- Turns on `disallow_subclassing_any`, `disallow_untyped_calls`, `check_untyped_defs` and `warn_return_any`.
- Replaces the dict-returning `crypto.encrypt()` / `make_test_message()` with `EncryptionTestDTO`, propagating through `upload_user_file` and tests, adds missing return-type annotations, and narrows generic collections. The vendored `actual.utils.openid` and the `proto.Message`-driven `actual.protobuf_models` are isolated via per-module overrides.