### PR TITLE
feat(bank_sync): add Enable Banking provider support

### DIFF
--- a/actual/__init__.py
+++ b/actual/__init__.py
@@ -684,9 +684,9 @@ class Actual(ActualServer):
             # actual uses 'startingBalance', that already comes in cents and should be enough for our purposes
             # https://github.com/actualbudget/actual/blob/f09f4af667ddd57e031dcdb0d428ae935aa2afad/packages/loot-core/src/server/accounts/sync.ts#L740-L752
             balance_to_use = new_transactions_data.data.balance
-            # For simpleFin, the startingBalance is actually the current balance, so we have to use it to deduce the
-            # actual startingBalance
-            if acct.account_sync_source and acct.account_sync_source.lower() == "simplefin":
+            # For simpleFin and Enable Banking, the startingBalance is actually the current
+            # balance, so we have to use it to deduce the actual startingBalance
+            if acct.account_sync_source and acct.account_sync_source.lower() in ("simplefin", "enablebanking"):
                 current_balance = new_transactions_data.data.balance
                 balance_to_use = current_balance - sum(t.transaction_amount.amount for t in new_transactions)
             if balance_to_use:

--- a/actual/api/bank_sync.py
+++ b/actual/api/bank_sync.py
@@ -5,7 +5,7 @@ import decimal
 import enum
 import typing
 
-from pydantic import AliasChoices, BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field, model_validator
 
 from actual.utils.title import title
 
@@ -50,6 +50,7 @@ class DebtorAccount(BaseModel):
 
 
 class BalanceType(enum.Enum):
+    # goCardless/Nordigen camelCase names.
     # See https://developer.gocardless.com/bank-account-data/balance#balance_type for full documentation
     CLOSING_AVAILABLE = "closingAvailable"
     CLOSING_BOOKED = "closingBooked"
@@ -65,6 +66,25 @@ class BalanceType(enum.Enum):
     OPENING_AVAILABLE = "openingAvailable"
     OPENING_CLEARED = "openingCleared"
     PREVIOUSLY_CLOSED_BOOKED = "previouslyClosedBooked"
+    # Enable Banking returns ISO 20022 external balance-type codes instead of the
+    # camelCase names above. https://enablebanking.com/docs/api/reference/#balance
+    ISO_CLOSING_BOOKED = "CLBD"
+    ISO_CLOSING_AVAILABLE = "CLAV"
+    ISO_INTERIM_BOOKED = "ITBD"
+    ISO_INTERIM_AVAILABLE = "ITAV"
+    ISO_OPENING_BOOKED = "OPBD"
+    ISO_OPENING_AVAILABLE = "OPAV"
+    ISO_FORWARD_AVAILABLE = "FWAV"
+    ISO_EXPECTED = "XPCD"
+    ISO_PREVIOUSLY_CLOSED_BOOKED = "PRCD"
+    ISO_INFORMATION = "INFO"
+
+    @classmethod
+    def _missing_(cls, value: object) -> BalanceType:
+        # Be lenient with unknown/unmapped balance-type codes: the balance type is
+        # informational only and not used in the sync reconciliation, so an unknown
+        # code from any provider should not break parsing of the whole response.
+        return cls.INFORMATION
 
 
 class Balance(BaseModel):
@@ -95,6 +115,55 @@ class TransactionItem(BaseModel):
     additional_information: str | None = Field(None, alias="additionalInformation")
     # simpleFin optional fields
     posted_date: datetime.date | None = Field(None, alias="postedDate")
+
+    @model_validator(mode="before")
+    @classmethod
+    def _normalize_enable_banking(cls, data: typing.Any) -> typing.Any:
+        """Map Enable Banking's native transaction shape onto the goCardless/simpleFin
+        field names this model already understands.
+
+        Enable Banking differs in several ways: the id is ``entry_reference``, the amount is
+        always positive with a separate ``credit_debit_indicator`` (``DBIT``/``CRDT``) carrying
+        the sign, there is no ``date`` field (only ``booking_date``/``transaction_date``), the
+        booked flag is a ``status`` string (``BOOK``), and the counterparty is a nested
+        ``creditor``/``debtor`` object rather than a flat ``creditorName``/``debtorName``.
+        """
+        if not isinstance(data, dict):
+            return data
+        if "entry_reference" not in data and "credit_debit_indicator" not in data:
+            return data  # not an Enable Banking payload, leave untouched
+        data = dict(data)
+        data.setdefault("transactionId", data.get("entry_reference"))
+        # amount: positive value + credit_debit_indicator -> signed transactionAmount
+        amount = data.get("transaction_amount") or data.get("transactionAmount")
+        if isinstance(amount, dict) and amount.get("amount") is not None:
+            value = decimal.Decimal(str(amount["amount"]))
+            if str(data.get("credit_debit_indicator", "")).upper() == "DBIT":
+                value = -value
+            data["transactionAmount"] = {"amount": str(value), "currency": amount.get("currency")}
+        # date: no dedicated field, derive from booking/transaction/value date
+        data.setdefault("date", data.get("booking_date") or data.get("transaction_date") or data.get("value_date"))
+        data.setdefault("bookingDate", data.get("booking_date"))
+        data.setdefault("valueDate", data.get("value_date"))
+        # booked flag from ISO status string
+        if "booked" not in data and "status" in data:
+            data["booked"] = str(data.get("status", "")).upper() == "BOOK"
+        # counterparty name from nested creditor/debtor
+        if "creditorName" not in data and "debtorName" not in data:
+            name = (data.get("creditor") or {}).get("name") or (data.get("debtor") or {}).get("name")
+            if name:
+                data["payeeName"] = data.get("payeeName") or name
+                data["debtorName"] = name
+        # counterparty account (iban) from nested creditor/debtor account
+        if "creditorAccount" not in data and "debtorAccount" not in data:
+            account = data.get("creditor_account") or data.get("debtor_account") or {}
+            if isinstance(account, dict) and account.get("iban"):
+                data["debtorAccount"] = {"iban": account["iban"]}
+        # remittance info comes as a list under a different key
+        remittance = data.get("remittance_information")
+        if "remittanceInformationUnstructuredArray" not in data and isinstance(remittance, list):
+            data["remittanceInformationUnstructuredArray"] = remittance
+        return data
 
     @property
     def imported_payee(self):

--- a/tests/test_bank_sync.py
+++ b/tests/test_bank_sync.py
@@ -6,7 +6,7 @@ import pytest
 from httpx import Client
 
 from actual import Actual, ActualBankSyncError, ActualError
-from actual.api.bank_sync import TransactionItem
+from actual.api.bank_sync import BalanceType, TransactionItem
 from actual.database import Banks
 from actual.queries import create_account
 from tests.conftest import RequestsMock
@@ -74,6 +74,56 @@ fail_response = {
     "reason": "The account needs your attention.",
 }
 
+# Enable Banking returns ISO 20022 balance-type codes (e.g. "ITBD") and a snake_case
+# transaction shape with a positive amount plus a separate credit/debit indicator.
+# All values below are synthetic.
+response_enable_banking = {
+    "balances": [
+        {
+            "balanceAmount": {"amount": 50000, "currency": "EUR"},
+            "balanceType": "ITBD",
+            "referenceDate": None,
+        }
+    ],
+    "startingBalance": 50000,
+    "transactions": {
+        "all": [
+            {
+                "entry_reference": "EB0000000000000001",
+                "transaction_amount": {"currency": "EUR", "amount": "25.50"},
+                "credit_debit_indicator": "DBIT",
+                "status": "BOOK",
+                "booking_date": "2024-06-13",
+                "transaction_date": "2024-06-13",
+                "creditor": {"name": "Example Shop"},
+                "creditor_account": {"iban": "NL00BANK0123456789"},
+                "remittance_information": ["Card payment"],
+            },
+            {
+                "entry_reference": "EB0000000000000002",
+                "transaction_amount": {"currency": "EUR", "amount": "100.00"},
+                "credit_debit_indicator": "CRDT",
+                "status": "BOOK",
+                "booking_date": "2024-06-12",
+                "transaction_date": "2024-06-12",
+                "debtor": {"name": "Jane Example"},
+                "remittance_information": ["Incoming transfer"],
+            },
+            # pending entry, should be ignored (status is not BOOK); amount kept at 0.00
+            # so it does not affect the deduced starting balance
+            {
+                "entry_reference": "EB0000000000000003",
+                "transaction_amount": {"currency": "EUR", "amount": "0.00"},
+                "credit_debit_indicator": "DBIT",
+                "status": "PDNG",
+                "transaction_date": "2024-06-13",
+            },
+        ],
+        "booked": [],
+        "pending": [],
+    },
+}
+
 
 def create_accounts(session, protocol: str):
     bank = create_account(session, "Bank")
@@ -85,11 +135,11 @@ def create_accounts(session, protocol: str):
     return bank
 
 
-def generate_bank_sync_data(mocker, starting_balance: int | None = None):
-    response_full = copy.deepcopy(response)
+def generate_bank_sync_data(mocker, starting_balance: int | None = None, base: dict | None = None):
+    response_full = copy.deepcopy(base if base is not None else response)
     if starting_balance:
         response_full["startingBalance"] = starting_balance
-    response_empty: dict = copy.deepcopy(response)
+    response_empty: dict = copy.deepcopy(base if base is not None else response)
     response_empty["transactions"]["all"] = []
     mocker.patch.object(Client, "get").return_value = RequestsMock({"status": "ok", "data": {"validated": True}})
     main_mock = mocker.patch.object(Client, "post")
@@ -211,6 +261,55 @@ def test_bank_sync_failed_response_exception(session, mocker):
         # now try to run the bank sync
         with pytest.raises(ActualBankSyncError):
             actual.run_bank_sync()
+
+
+@pytest.fixture
+def bank_sync_data_enable_banking(mocker):
+    return generate_bank_sync_data(mocker, base=response_enable_banking)
+
+
+def test_full_bank_sync_enable_banking(session, bank_sync_data_enable_banking):
+    with Actual(token="foo") as actual:
+        actual._session = session
+        create_accounts(session, "enableBanking")
+
+        imported_transactions = actual.run_bank_sync()
+        session.commit()
+        # starting balance + 2 booked transactions (the pending entry is skipped)
+        assert len(imported_transactions) == 3
+
+        # Enable Banking's startingBalance is the *current* balance (like simpleFin), so the
+        # starting-balance transaction is deduced: 500.00 - (100.00 - 25.50) = 425.50
+        assert imported_transactions[0].payee.name == "Starting Balance"
+        assert imported_transactions[0].get_amount() == decimal.Decimal("425.50")
+
+        # CRDT -> positive amount, payee taken from the nested debtor object
+        assert imported_transactions[1].financial_id == "EB0000000000000002"
+        assert imported_transactions[1].get_date() == datetime.date(2024, 6, 12)
+        assert imported_transactions[1].get_amount() == decimal.Decimal("100.00")
+        assert imported_transactions[1].payee.name == "Jane Example"
+
+        # DBIT -> negated amount, payee taken from the nested creditor object
+        assert imported_transactions[2].financial_id == "EB0000000000000001"
+        assert imported_transactions[2].get_date() == datetime.date(2024, 6, 13)
+        assert imported_transactions[2].get_amount() == decimal.Decimal("-25.50")
+        assert imported_transactions[2].payee.name == "Example Shop"
+
+        # the next call should do nothing
+        assert actual.run_bank_sync() == []
+
+
+def test_enable_banking_transaction_item_parsing():
+    # ISO 20022 balance-type code must parse instead of raising
+    assert BalanceType("ITBD") is BalanceType.ISO_INTERIM_BOOKED
+    assert BalanceType("some-unknown-code") is BalanceType.INFORMATION
+    # a DBIT entry is normalized to a negative signed amount with a derived date
+    item = TransactionItem.model_validate(response_enable_banking["transactions"]["all"][0])
+    assert item.transaction_id == "EB0000000000000001"
+    assert item.booked is True
+    assert item.date == datetime.date(2024, 6, 13)
+    assert item.transaction_amount.amount == decimal.Decimal("-25.50")
+    assert item.payee_name == "Example Shop"
 
 
 def test_bank_sync_invalid_input(session, mocker):


### PR DESCRIPTION
Closes #208.

`run_bank_sync()` raised a `ValidationError` for Enable Banking accounts because the response models only cover goCardless and simpleFin. Enable Banking is a selectable provider in the Actual UI (alongside Pluggy.ai), but the server returns its responses in native form.

### Changes

- **`BalanceType`**: add ISO 20022 external balance-type codes (`ITBD`, `CLBD`, `ITAV`, ...) and a lenient `_missing_` fallback to `INFORMATION` (the balance type is informational and not used in reconciliation).
- **`TransactionItem`**: a `model_validator(mode="before")` normalizes Enable Banking's native shape onto the existing field names:
  - `entry_reference` → `transactionId`
  - positive `transaction_amount` + `credit_debit_indicator` (DBIT/CRDT) → signed `transactionAmount`
  - `booking_date`/`transaction_date` → `date`
  - `status == "BOOK"` → `booked`
  - nested `creditor`/`debtor` → `payeeName`/`debtorName` (+ iban)

  It only triggers for Enable Banking payloads, so goCardless/simpleFin parsing is untouched.
- **`run_bank_sync` starting balance**: treat Enable Banking like simpleFin (its `startingBalance` is the current balance), so the first-sync starting balance is deduced rather than double-counting the windowed transactions.

### Tests

- `test_full_bank_sync_enable_banking`: full sync against a synthetic Enable Banking response (DBIT/CRDT signs, nested counterparties, pending skipped, deduced starting balance).
- `test_enable_banking_transaction_item_parsing`: ISO balance code + transaction normalization in isolation.

All existing bank-sync tests still pass; `ruff check` / `ruff format` clean.

### Note for review

The `startingBalance`-is-current behavior and the exact ISO codes are based on observed Enable Banking responses (Actual server 26.6.0). Happy to adjust if you have reference payloads that differ.
