### PR TITLE
refactor: Enable mypy strict mode

### DIFF
--- a/actual/__init__.py
+++ b/actual/__init__.py
@@ -12,7 +12,7 @@ import warnings
 import zipfile
 from collections.abc import Sequence
 from os import PathLike
-from typing import IO, cast
+from typing import IO, Any, cast
 
 import httpx
 from sqlalchemy.engine import Engine
@@ -71,7 +71,7 @@ class Actual(ActualServer):
         data_dir: str | pathlib.Path | None = None,
         cert: bool | ssl.SSLContext | str = True,
         bootstrap: bool = False,
-        sa_kwargs: dict | None = None,
+        sa_kwargs: dict[str, Any] | None = None,
         extra_headers: dict[str, str] | None = None,
         timeout: float | httpx.Timeout | None = 60.0,
     ):
@@ -150,7 +150,7 @@ class Actual(ActualServer):
             self.download_budget(self._encryption_password)
         return self
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         if self._session:
             self._session.close()
         if self.engine:
@@ -222,7 +222,7 @@ class Actual(ActualServer):
             raise UnknownFileId(f"Multiple files found with identifier '{file_id}'")
         return self.set_file(selected_files[0])
 
-    def run_migrations(self, migration_files: list[str]):
+    def run_migrations(self, migration_files: list[str]) -> None:
         """
         Runs the migration files, skipping the ones that have already been run.
 
@@ -253,7 +253,7 @@ class Actual(ActualServer):
             raise ActualError("Engine not initialized. Download or create a budget first.")
         self._database_metadata = reflect_model(self.engine)
 
-    def create_budget(self, budget_name: str):
+    def create_budget(self, budget_name: str) -> None:
         """
         Creates a budget using the remote server default database and migrations.
 
@@ -295,11 +295,11 @@ class Actual(ActualServer):
             get_or_create_clock(session, self._hulc_client)
             session.commit()
 
-    def rename_budget(self, budget_name: str):
+    def rename_budget(self, budget_name: str) -> None:
         """Renames the budget with the given name."""
         self.update_user_file_name(self.file.file_id, budget_name)
 
-    def delete_budget(self):
+    def delete_budget(self) -> None:
         """Deletes the currently loaded file from the server."""
         self.delete_user_file(self.file.file_id)
         # reset group id, as file cannot be synced anymore
@@ -358,7 +358,7 @@ class Actual(ActualServer):
                 output_file.write(content)
         return content
 
-    def encrypt(self, encryption_password: str):
+    def encrypt(self, encryption_password: str) -> None:
         """
         Encrypts the local database using a new key, and re-uploads to the server.
 
@@ -417,7 +417,7 @@ class Actual(ActualServer):
                 raise ActualEncryptionError("Budget is encrypted but password was not provided")
             self.encrypt(self._encryption_password)
 
-    def reupload_budget(self):
+    def reupload_budget(self) -> None:
         """
         Resets the user file on the backend and re-uploads the current copy instead.
 
@@ -477,13 +477,13 @@ class Actual(ActualServer):
             s.commit()
             return changes
 
-    def get_metadata(self) -> dict:
+    def get_metadata(self) -> dict[str, Any]:
         """Gets the content of the `metadata.json` file."""
         metadata_file = self.data_dir / "metadata.json"
         # Here, we trust the metadata will have the correct format
-        return cast(dict, json.loads(metadata_file.read_text()))
+        return cast(dict[str, Any], json.loads(metadata_file.read_text()))
 
-    def update_metadata(self, patch: dict):
+    def update_metadata(self, patch: dict[str, Any]) -> None:
         """
         Updates the `metadata.json` from the Actual file with the patch fields.
 
@@ -497,7 +497,7 @@ class Actual(ActualServer):
             config = patch
         metadata_file.write_text(json.dumps(config, separators=(",", ":")))
 
-    def download_budget(self, encryption_password: str | None = None):
+    def download_budget(self, encryption_password: str | None = None) -> None:
         """
         Downloads the budget file from the remote, applying all following changes required by the server.
 
@@ -532,6 +532,8 @@ class Actual(ActualServer):
                 if self._master_key is None:
                     raise ActualDecryptionError("Master encryption key is not set.")
                 file_info = self.get_user_file_info(self.file.file_id)
+                if file_info.data.encrypt_meta is None:
+                    raise ActualDecryptionError("Encryption metadata is missing on the user file.")
                 # decrypt file bytes
                 file_bytes = decrypt_from_meta(self._master_key, file_bytes, file_info.data.encrypt_meta)
             self.import_zip(io.BytesIO(file_bytes))
@@ -563,7 +565,7 @@ class Actual(ActualServer):
             self._master_key = create_key_buffer(encryption_password, key_info.data.salt)
         return self._master_key
 
-    def import_zip(self, file_bytes: str | PathLike[str] | IO[bytes]):
+    def import_zip(self, file_bytes: str | PathLike[str] | IO[bytes]) -> None:
         """
         Imports a zip file as the current database, as well as generating the local reflected session.
 
@@ -628,7 +630,7 @@ class Actual(ActualServer):
                 session.commit()
         return changeset
 
-    def commit(self):
+    def commit(self) -> None:
         """
         Adds all pending entries done to the local database, and sends a sync request to the remote server.
 
@@ -654,7 +656,7 @@ class Actual(ActualServer):
         if self.file.group_id:  # only files with a group id can be synced
             self.sync_sync(req)
 
-    def run_rules(self, transactions: Sequence[Transactions] | None = None):
+    def run_rules(self, transactions: Sequence[Transactions] | None = None) -> None:
         """Runs all the stored rules on the database on all transactions, without any filters."""
         if transactions is None:
             transactions = get_transactions(self.session)

--- a/actual/api/__init__.py
+++ b/actual/api/__init__.py
@@ -161,7 +161,7 @@ class ActualServer:
         self._token = login_response.data.token
         return login_response
 
-    def headers(self, file_id: str | None = None, extra_headers: dict | None = None) -> dict:
+    def headers(self, file_id: str | None = None, extra_headers: dict[str, str] | None = None) -> dict[str, str]:
         """
         Generates a header based on the stored token for the connection.
 
@@ -280,7 +280,7 @@ class ActualServer:
         response.raise_for_status()
         return StatusDTO.model_validate(response.json())
 
-    def delete_user_file(self, file_id: str):
+    def delete_user_file(self, file_id: str) -> StatusDTO:
         """Deletes the user file loaded from the remote server."""
         response = self._requests_session.post(
             Endpoints.DELETE_USER_FILE.value, json={"fileId": file_id, "token": self._token}

--- a/actual/api/bank_sync.py
+++ b/actual/api/bank_sync.py
@@ -45,7 +45,7 @@ class DebtorAccount(BaseModel):
     iban: str
 
     @property
-    def masked_iban(self):
+    def masked_iban(self) -> str:
         return f"({self.iban[:4]} XXX {self.iban[-4:]})"
 
 
@@ -97,7 +97,7 @@ class TransactionItem(BaseModel):
     posted_date: datetime.date | None = Field(None, alias="postedDate")
 
     @property
-    def imported_payee(self):
+    def imported_payee(self) -> str:
         """Deprecated method to convert the payee name. Use the payee_name instead."""
         name_parts = []
         name = self.payee or self.notes or self.additional_information

--- a/actual/api/models.py
+++ b/actual/api/models.py
@@ -50,7 +50,7 @@ class Endpoints(enum.Enum):
     OPEN_ID_ENABLE = "openid/enable"
     OPEN_ID_DISABLE = "openid/disable"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.value
 
 

--- a/actual/budgets.py
+++ b/actual/budgets.py
@@ -1,6 +1,7 @@
 import dataclasses
 import datetime
 import decimal
+import typing
 from collections.abc import Iterator
 
 from sqlmodel import Session, col, select
@@ -93,7 +94,7 @@ class BudgetCategory(_HasDatabaseObject):
             return False
         return bool(self.budget.carryover)
 
-    def as_dict(self) -> dict:
+    def as_dict(self) -> dict[str, str | bool | decimal.Decimal | None]:
         """
         Converts the budget category to a dictionary representation.
 
@@ -140,7 +141,7 @@ class BudgetCategoryGroup(_HasDatabaseObject):
         """Sum of all accumulated balances from the categories under this category group."""
         return sum([c.accumulated_balance for c in self.categories], start=decimal.Decimal(0))
 
-    def as_dict(self) -> dict:
+    def as_dict(self) -> dict[str, typing.Any]:
         """
         Converts the budget category group to a dictionary representation, including nested categories.
 
@@ -183,7 +184,7 @@ class IncomeCategory(_HasDatabaseObject):
     If a budget was not set for the month, it will be set to `None`, and budgeted amount assumed to be zero.
     """
 
-    def as_dict(self) -> dict:
+    def as_dict(self) -> dict[str, str | bool | decimal.Decimal | None]:
         """
         Converts the income category to a dictionary representation.
         """
@@ -225,7 +226,7 @@ class IncomeCategoryGroup(_HasDatabaseObject):
         """
         return sum([c.budgeted for c in self.categories], start=decimal.Decimal(0))
 
-    def as_dict(self) -> dict:
+    def as_dict(self) -> dict[str, typing.Any]:
         """
         Converts the income category group to a dictionary representation, including nested categories.
         """
@@ -342,7 +343,7 @@ class EnvelopeBudget(BaseBudget):
         return self.received + self.from_last_month
 
     @property
-    def to_budget(self):
+    def to_budget(self) -> decimal.Decimal:
         """
         The amount of money available for budgeting.
 
@@ -351,7 +352,7 @@ class EnvelopeBudget(BaseBudget):
         """
         return self.available_funds - self.budgeted - self.for_next_month + self.last_month_overspent
 
-    def as_dict(self) -> dict:
+    def as_dict(self) -> dict[str, typing.Any]:
         """
         Converts the envelope budget to a dictionary representation, including all category groups.
 
@@ -400,7 +401,7 @@ class TrackingBudget(BaseBudget):
         """The amount of income budgeted for the current month."""
         return sum([cat.budgeted for cat in self.income_category_groups], start=decimal.Decimal(0))
 
-    def as_dict(self) -> dict:
+    def as_dict(self) -> dict[str, typing.Any]:
         """
         Converts the tracking budget to a dictionary representation, including all category groups.
 
@@ -434,7 +435,7 @@ class BudgetList(list[EnvelopeBudget | TrackingBudget]):
     :param is_tracking_budget: Whether the budgets are tracking budgets (True) or envelope budgets (False).
     """
 
-    def __init__(self, iterable, is_tracking_budget: bool = False):
+    def __init__(self, iterable: typing.Iterable["EnvelopeBudget | TrackingBudget"], is_tracking_budget: bool = False):
         super().__init__(iterable)
         self.is_tracking_budget: bool = is_tracking_budget
 
@@ -489,14 +490,14 @@ def _get_category_detailed_budget(
     if not budget:
         # create a temporary budget
         range_start, range_end = month_range(month)
-        balance = s.scalar(_balance_base_query(s, range_start, range_end, category=category))
+        scalar_balance = s.scalar(_balance_base_query(s, range_start, range_end, category=category))
         budgeted = decimal.Decimal(0)
-        spent = cents_to_decimal(balance)
+        spent = cents_to_decimal(scalar_balance)
     else:
         budgeted = budget.get_amount()
         spent = budget.balance
     # Balance is the simple subtraction of the spent from the budget amount
-    balance = budgeted + spent
+    balance: decimal.Decimal = budgeted + spent
     # The accumulated balance relates to a previous budget
     return BudgetCategory(
         category,
@@ -578,7 +579,7 @@ def _calculate_accumulated_balance(
 def _process_expense_categories(
     s: Session,
     month: datetime.date,
-    category_groups: list[CategoryGroups],
+    category_groups: typing.Sequence[CategoryGroups],
     previous_budget: EnvelopeBudget | TrackingBudget | None,
     is_tracking: bool,
 ) -> list[BudgetCategoryGroup]:
@@ -595,7 +596,7 @@ def _process_expense_categories(
 
 
 def _process_income_categories(
-    s: Session, month: datetime.date, income_category_groups: list[CategoryGroups], is_tracking: bool
+    s: Session, month: datetime.date, income_category_groups: typing.Sequence[CategoryGroups], is_tracking: bool
 ) -> list[IncomeCategoryGroup]:
     """Processes all income category groups for a given month."""
     income_cat_group_list: list[IncomeCategoryGroup] = []

--- a/actual/cli/main.py
+++ b/actual/cli/main.py
@@ -28,7 +28,7 @@ state: State = State()
 
 
 @app.callback()
-def main(output: OutputType = typer.Option("table", "--output", "-o", help="Output format: table or json")):
+def main(output: OutputType = typer.Option("table", "--output", "-o", help="Output format: table or json")) -> None:
     if output:
         state.output = output
 
@@ -42,7 +42,7 @@ def init(
     ),
     context: str | None = typer.Option(None, "--context", help="Context for this budget context"),
     file_id: str | None = typer.Option(None, "--file", help="File ID or name on the remote server"),
-):
+) -> None:
     """
     Initializes an actual budget config interactively if options are not provided.
     """
@@ -92,7 +92,7 @@ def init(
 
 
 @app.command()
-def use_context(context: str = typer.Argument(..., help="Context for this budget context")):
+def use_context(context: str = typer.Argument(..., help="Context for this budget context")) -> None:
     """Sets the default context for the CLI."""
     if context not in config.budgets:
         raise ValueError(f"Context '{context}' is not registered. Choose one from {list(config.budgets.keys())}")
@@ -101,7 +101,7 @@ def use_context(context: str = typer.Argument(..., help="Context for this budget
 
 
 @app.command()
-def get_contexts():
+def get_contexts() -> None:
     """Shows all configured contexts."""
     if state.output == OutputType.table:
         table = Table(title="Contexts")
@@ -127,7 +127,7 @@ def get_contexts():
 
 
 @app.command()
-def remove_context(context: str = typer.Argument(..., help="Context to be removed")):
+def remove_context(context: str = typer.Argument(..., help="Context to be removed")) -> None:
     """Removes a configured context from the configuration."""
     if context not in config.budgets:
         raise ValueError(f"Context '{context}' is not registered. Choose one from {list(config.budgets.keys())}")
@@ -137,7 +137,7 @@ def remove_context(context: str = typer.Argument(..., help="Context to be remove
 
 
 @app.command()
-def version():
+def version() -> None:
     """
     Shows the library and server version.
     """
@@ -151,7 +151,7 @@ def version():
 
 
 @app.command()
-def accounts():
+def accounts() -> None:
     """
     Show all accounts.
     """
@@ -181,7 +181,7 @@ def accounts():
 
 
 @app.command()
-def transactions():
+def transactions() -> None:
     """
     Show all transactions.
     """
@@ -223,7 +223,7 @@ def transactions():
 
 
 @app.command()
-def payees():
+def payees() -> None:
     """
     Show all payees.
     """
@@ -250,7 +250,9 @@ def payees():
 
 
 @app.command()
-def budget(month: datetime.datetime | None = typer.Argument(default=None, help="Month for which to show the budget")):
+def budget(
+    month: datetime.datetime | None = typer.Argument(default=None, help="Month for which to show the budget"),
+) -> None:
     """
     Shows the budget for a certain month.
     """
@@ -343,7 +345,7 @@ def export(
         help="Name of the file to export, in zip format. "
         "Leave it empty to export it to the current folder with default name.",
     ),
-):
+) -> None:
     """
     Generates an export from the budget (for CLI backups).
 
@@ -365,7 +367,7 @@ def export(
 
 
 @app.command()
-def metadata():
+def metadata() -> None:
     """Displays all metadata for the current budget."""
     with config.actual() as actual:
         actual_metadata = actual.get_metadata()

--- a/actual/crypto.py
+++ b/actual/crypto.py
@@ -60,8 +60,10 @@ def decrypt(master_key: bytes, iv: bytes, ciphertext: bytes, auth_tag: bytes | N
         raise ActualDecryptionError("Error decrypting file. Is the encryption key correct?") from None
 
 
-def decrypt_from_meta(master_key: bytes, ciphertext: bytes, encrypt_meta) -> bytes:
+def decrypt_from_meta(master_key: bytes, ciphertext: bytes, encrypt_meta: EncryptMetaDTO) -> bytes:
     """Decrypts a cyphertext (actual database) using AES-GCM using the provided metadata."""
+    if encrypt_meta.iv is None or encrypt_meta.auth_tag is None:
+        raise ActualDecryptionError("Encryption metadata is missing required iv or authTag.")
     iv = base64.b64decode(encrypt_meta.iv)
     auth_tag = base64.b64decode(encrypt_meta.auth_tag)
     return decrypt(master_key, iv, ciphertext, auth_tag)
@@ -79,7 +81,7 @@ def make_test_message(key_id: str, key: bytes) -> EncryptionTestDTO:
     return encrypt(key_id, key, binary_message)
 
 
-def is_uuid(text: str, version: int = 4):
+def is_uuid(text: str, version: int = 4) -> bool:
     """
     Check if uuid_to_test is a valid UUID. Taken from [this thread](https://stackoverflow.com/a/54254115/12681470)
 

--- a/actual/database.py
+++ b/actual/database.py
@@ -156,7 +156,7 @@ def apply_change(
     session.exec(insert_stmt)
 
 
-def strong_reference_session(session: Session):
+def strong_reference_session(session: Session) -> Session:
     """
     References a session so that all object instances created on the session can be tracked.
 
@@ -165,7 +165,7 @@ def strong_reference_session(session: Session):
     """
 
     @event.listens_for(session, "before_flush")
-    def before_flush(sess, flush_context, instances):
+    def before_flush(sess: Session, flush_context: Any, instances: Any) -> None:
         if len(sess.deleted):
             raise ActualInvalidOperationError(
                 "Actual does not allow deleting entries, set the `tombstone` to 1 instead or call the .delete() method"
@@ -185,9 +185,9 @@ def strong_reference_session(session: Session):
     @event.listens_for(session, "after_commit")
     @event.listens_for(session, "after_soft_rollback")
     def after_commit_or_rollback(
-        sess,
-        previous_transaction=None,
-    ):
+        sess: Session,
+        previous_transaction: Any = None,
+    ) -> None:
         if sess.info.get("messages"):
             del sess.info["messages"]
 
@@ -543,13 +543,13 @@ class MessagesClock(SQLModel, table=True):
     id: int | None = Field(default=None, sa_column=Column("id", Integer, primary_key=True))
     clock: str | None = Field(default=None, sa_column=Column("clock", Text))
 
-    def get_clock(self) -> dict:
+    def get_clock(self) -> dict[str, Any]:
         """Gets the clock from JSON text to a dictionary with fields `timestamp` and `merkle`."""
         if self.clock is None:
             raise ValueError("Clock is not set")
-        return cast(dict, json.loads(self.clock))
+        return cast(dict[str, Any], json.loads(self.clock))
 
-    def set_clock(self, value: dict):
+    def set_clock(self, value: dict[str, Any]) -> None:
         """Sets the clock from a dictionary and stores it in the correct format."""
         self.clock = json.dumps(value, separators=(",", ":"))
 
@@ -820,11 +820,11 @@ class Transactions(BaseModel, table=True):
             raise ValueError("Transaction date is not set")
         return int_to_date(self.date)
 
-    def set_date(self, date: datetime.date):
+    def set_date(self, date: datetime.date) -> None:
         """Sets the transaction date as a datetime.date object, instead of as a string."""
         self.date = date_to_int(date)
 
-    def set_amount(self, amount: decimal.Decimal | int | float):
+    def set_amount(self, amount: decimal.Decimal | int | float) -> None:
         """Sets the amount as a decimal.Decimal object, instead of as an integer representing the number of cents."""
         self.amount = decimal_to_cents(amount)
 
@@ -833,7 +833,7 @@ class Transactions(BaseModel, table=True):
         return cents_to_decimal(self.amount)
 
     @validates("cleared")
-    def validate_cleared(self, key, v):
+    def validate_cleared(self, key: str, v: Any) -> Any:
         """Add an validator which ensures that clearing parent transactions also affects all splits"""
 
         # Validation only performed on parent transactions where cleared is changed
@@ -889,11 +889,11 @@ class ZeroBudgetMonths(BaseModel, table=True):
         """Returns the month as a datetime.date object, instead of as a string."""
         return int_to_date(self.id.replace("-", ""), month_only=True)
 
-    def set_month(self, month: datetime.date):
+    def set_month(self, month: datetime.date) -> None:
         """Sets the month as a datetime.date object, instead of as a string."""
         self.id = datetime.date.strftime(month, "%Y-%m")
 
-    def set_amount(self, amount: decimal.Decimal | int | float):
+    def set_amount(self, amount: decimal.Decimal | int | float) -> None:
         """Sets the amount as a decimal.Decimal object, instead of as an integer representing the number of cents."""
         self.buffered = decimal_to_cents(amount)
 
@@ -924,7 +924,7 @@ class BaseBudgets(BaseModel):
             raise ValueError("Budget month is not set")
         return int_to_date(self.month, month_only=True)
 
-    def set_date(self, date: datetime.date):
+    def set_date(self, date: datetime.date) -> None:
         """
         Sets the transaction date as a datetime.date object, instead of as a string.
 
@@ -933,7 +933,7 @@ class BaseBudgets(BaseModel):
         """
         self.month = date_to_int(date, month_only=True)
 
-    def set_amount(self, amount: decimal.Decimal | int | float):
+    def set_amount(self, amount: decimal.Decimal | int | float) -> None:
         """Sets the amount as a decimal.Decimal object, instead of as an integer representing the number of cents."""
         self.amount = decimal_to_cents(amount)
 

--- a/actual/protobuf_models.py
+++ b/actual/protobuf_models.py
@@ -41,7 +41,7 @@ class HULC_Client:
         parsed_ts = datetime.datetime.fromisoformat(ts_string)
         return cls(segments[-1], int(segments[-2], 16), parsed_ts)
 
-    def __str__(self):
+    def __str__(self) -> str:
         ts = self.ts or datetime.datetime(1970, 1, 1, 0, 0, 0)
         return f"{ts.isoformat(timespec='milliseconds')}Z-{self.initial_count:0>4X}-{self.client_id}"
 
@@ -178,7 +178,7 @@ class SyncRequest(proto.Message):
     def set_null_timestamp(self, client_id: str | None = None) -> str:
         return self.set_timestamp(client_id, datetime.datetime(1970, 1, 1, 0, 0, 0, 0))
 
-    def set_messages(self, messages: list[Message], client: HULC_Client, master_key: bytes | None = None):
+    def set_messages(self, messages: list[Message], client: HULC_Client, master_key: bytes | None = None) -> None:
         if not self.messages:
             self.messages = []
         for message in messages:

--- a/actual/queries.py
+++ b/actual/queries.py
@@ -11,7 +11,6 @@ import sqlalchemy
 from pydantic import TypeAdapter
 from sqlalchemy import func
 from sqlalchemy.orm import joinedload
-from sqlalchemy.sql.expression import Select
 from sqlmodel import Session, col, select
 from sqlmodel.sql.expression import SelectOfScalar
 
@@ -100,7 +99,7 @@ def _balance_base_query(
     end_date: datetime.date | None,
     account: Accounts | str | None = None,
     category: Categories | str | None = None,
-) -> Select:
+) -> SelectOfScalar[int | None]:
     query = select(func.coalesce(func.sum(Transactions.amount), 0)).where(
         Transactions.is_parent == 0,
         Transactions.tombstone == 0,
@@ -557,7 +556,7 @@ def _base_query(instance: type[T], name: str | None = None, include_deleted: boo
 
 def get_category_groups(
     s: Session, name: str | None = None, include_deleted: bool = False, is_income: bool | None = None
-):
+) -> typing.Sequence[CategoryGroups]:
     """
     Returns a list of all available category groups.
 

--- a/actual/rules.py
+++ b/actual/rules.py
@@ -61,11 +61,11 @@ class BetweenValue(pydantic.BaseModel):
     num_1: int | float = pydantic.Field(alias="num1")
     num_2: int | float = pydantic.Field(alias="num2")
 
-    def __str__(self):
+    def __str__(self) -> str:
         return f"({self.num_1}, {self.num_2})"
 
     @pydantic.model_validator(mode="after")
-    def convert_value(self):
+    def convert_value(self) -> BetweenValue:
         if isinstance(self.num_1, float):
             self.num_1 = int(self.num_1 * 100)
         if isinstance(self.num_2, float):
@@ -187,7 +187,7 @@ def condition_evaluation(
     op: ConditionType,
     true_value: int | list[str] | str | datetime.date | BetweenValue | Schedule | None,
     self_value: int | list[str] | str | datetime.date | BetweenValue | Schedule | None,
-    options: dict | None = None,
+    options: dict[str, typing.Any] | None = None,
     session: Session | None = None,
 ) -> bool:
     """Helper function to evaluate the condition based on the true_value, value found on the transaction, and the
@@ -272,7 +272,7 @@ def _coerce_value(
 ) -> list[str] | Schedule | BetweenValue | datetime.date: ...
 
 
-def _coerce_value(v):
+def _coerce_value(v: typing.Any) -> typing.Any:
     """Coerce convenience input types to their stored representations."""
     if isinstance(v, float):
         return int(v * 100)
@@ -325,7 +325,7 @@ class Condition(pydantic.BaseModel):
         pydantic.BeforeValidator(_coerce_value),
     ]
     type: ValueType = ValueType.ID
-    options: dict | None = None
+    options: dict[str, typing.Any] | None = None
 
     def __str__(self) -> str:
         v = f"'{self.value}'" if isinstance(self.value, str) or isinstance(self.value, Schedule) else str(self.value)
@@ -343,7 +343,7 @@ class Condition(pydantic.BaseModel):
         return get_value(self.value, self.type)
 
     @pydantic.model_validator(mode="after")
-    def convert_value(self):
+    def convert_value(self) -> Condition:
         if self.field in ("amount_inflow", "amount_outflow") and self.options is None:
             self.options = {self.field.split("_")[1]: True}
             self.value = abs(self.value)  # type: ignore[arg-type]
@@ -351,7 +351,7 @@ class Condition(pydantic.BaseModel):
         return self
 
     @pydantic.model_validator(mode="after")
-    def check_operation_type(self):
+    def check_operation_type(self) -> Condition:
         if "type" not in self.model_fields_set:
             self.type = ValueType.from_field(self.field)
         # check if types are fine
@@ -438,13 +438,13 @@ class Action(pydantic.BaseModel):
 
     @pydantic.field_validator("value", mode="before")
     @classmethod
-    def convert_value(cls, value, info):
+    def convert_value(cls, value: typing.Any, info: pydantic.ValidationInfo) -> typing.Any:
         if info.data.get("field") == "cleared" and value in (0, 1):
             return bool(value)
         return value
 
     @pydantic.model_validator(mode="after")
-    def check_operation_type(self):
+    def check_operation_type(self) -> Action:
         if "type" not in self.model_fields_set:
             if self.field is not None:
                 self.type = ValueType.from_field(self.field)
@@ -534,7 +534,7 @@ class Rule(pydantic.BaseModel):
     )
 
     @pydantic.model_validator(mode="before")
-    def correct_operation(cls, value):
+    def correct_operation(cls, value: typing.Any) -> typing.Any:
         """If the user provides the same `all` or `any` that the frontend provides, we fix it silently to `and` and
         `or` respectively."""
         if value.get("operation") == "all":
@@ -543,7 +543,7 @@ class Rule(pydantic.BaseModel):
             value["operation"] = "or"
         return value
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Returns a readable string representation of the rule."""
         operation = "all" if self.operation == "and" else "any"
         conditions = f" {self.operation} ".join([str(c) for c in self.conditions])
@@ -650,7 +650,7 @@ class RuleSet:
 
     rules: list[Rule]
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Returns a readable string representation of the ruleset."""
         return "\n".join([str(r) for r in self.rules])
 
@@ -662,7 +662,7 @@ class RuleSet:
         self,
         transaction: Transactions | typing.Sequence[Transactions],
         stage: typing.Literal["pre", "post", None],
-    ):
+    ) -> None:
         for rule in [r for r in self.rules if r.stage == stage]:
             if isinstance(transaction, Transactions):
                 rule.run(transaction)
@@ -674,7 +674,7 @@ class RuleSet:
         self,
         transaction: Transactions | typing.Sequence[Transactions],
         stage: typing.Literal["all", "pre", "post", None] = "all",
-    ):
+    ) -> None:
         """
         Runs the rules of the Ruleset for every transaction on the list.
 
@@ -691,6 +691,6 @@ class RuleSet:
         else:
             self._run(transaction, stage)  # noqa
 
-    def add(self, rule: Rule):
+    def add(self, rule: Rule) -> None:
         """Adds a new rule to the ruleset."""
         self.rules.append(rule)

--- a/actual/schedules.py
+++ b/actual/schedules.py
@@ -217,7 +217,7 @@ class Schedule(pydantic.BaseModel):
         return handler(self)
 
     @pydantic.model_validator(mode="after")
-    def validate_end_date(self):
+    def validate_end_date(self) -> "Schedule":
         if self.end_mode == EndMode.ON_DATE and self.end_date is None:
             raise ValueError("endDate cannot be 'None' when ")
         if self.end_date is None:

--- a/actual/utils/changeset.py
+++ b/actual/utils/changeset.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from typing import Any
 
 from sqlmodel import Column, Session, select
 
@@ -23,7 +24,7 @@ class Changeset:
 
     table: type[BaseModel] = field(metadata={"description": "The SQLModel reference to the table hosting the data."})
     id: str = field(metadata={"description": "The unique id of the row that was inserted or updated."})
-    values: dict[Column, str | int | float | bool | None] = field(
+    values: dict[Column[Any], str | int | float | bool | None] = field(
         metadata={
             "description": "The list of values that were updated on the remote server, using column names as keys."
         }

--- a/actual/utils/title.py
+++ b/actual/utils/title.py
@@ -159,7 +159,7 @@ regex = re.compile(
 )
 
 
-def convert_to_regexp(special_characters: list[str]):
+def convert_to_regexp(special_characters: list[str]) -> list[tuple[re.Pattern[str], str]]:
     return [(re.compile(rf"\b{s}\b", re.IGNORECASE), s) for s in special_characters]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,19 +103,7 @@ max-complexity = 18
 
 [tool.mypy]
 plugins = ["pydantic.mypy"]
-## TODO: Work one by one until we can enable --strict mode for mypy.
-# disallow_any_generics = true
-disallow_subclassing_any = true
-disallow_untyped_calls = true
-# disallow_untyped_defs = true
-# disallow_incomplete_defs = true
-check_untyped_defs = true
-disallow_untyped_decorators = true
-warn_redundant_casts = true
-warn_unused_ignores = true
-warn_return_any = true
-no_implicit_reexport = true
-strict_equality = true
+strict = true
 
 [[tool.mypy.overrides]]
 module = ["proto", "proto.*", "testcontainers", "testcontainers.*"]


### PR DESCRIPTION
Enable the remaining strict flags (disallow_any_generics, disallow_untyped_defs, disallow_incomplete_defs) and consolidate to `strict = true` since all individual strict checks are now satisfied.

- Annotate remaining untyped functions and parameters across the library.
- Tighten generic types: `dict` -> `dict[str, Any]`, `Column` -> `Column[Any]`, `Select` -> `SelectOfScalar[int | None]`. For some of them, there was no real better choice than choosing `Any`.
- Raise `ActualDecryptionError` when optional encryption metadata fields are missing instead of letting `b64decode(None)` fail.
- Rename a shadowed `balance` local in `_get_category_detailed_budget` to keep the Decimal-typed result distinct from the `int | None` scalar query result.